### PR TITLE
SUOPA-148 Theme taxonomy fields

### DIFF
--- a/conf/cmi/core.entity_form_display.taxonomy_term.theme.default.yml
+++ b/conf/cmi/core.entity_form_display.taxonomy_term.theme.default.yml
@@ -3,17 +3,50 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.media_image_browser
+    - field.field.taxonomy_term.theme.field_liftup_image
+    - field.field.taxonomy_term.theme.field_paragraphs
     - taxonomy.vocabulary.theme
   module:
+    - entity_browser
+    - hide_revision_field
+    - paragraphs
     - path
 id: taxonomy_term.theme.default
 targetEntityType: taxonomy_term
 bundle: theme
 mode: default
 content:
+  field_liftup_image:
+    type: entity_browser_entity_reference
+    weight: 1
+    settings:
+      entity_browser: media_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: true
+      open: true
+      selection_mode: selection_append
+      field_widget_display_settings:
+        view_mode: default
+    third_party_settings: {  }
+    region: content
+  field_paragraphs:
+    type: entity_reference_paragraphs
+    weight: 2
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
+    region: content
   langcode:
     type: language_select
-    weight: 1
+    weight: 3
     region: content
     settings:
       include_locked: true
@@ -28,12 +61,24 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 3
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 6
+    region: content
+    settings:
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   translation:
-    weight: 2
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.media.image.theme_teaser_liftup.yml
+++ b/conf/cmi/core.entity_view_display.media.image.theme_teaser_liftup.yml
@@ -1,0 +1,31 @@
+uuid: c49970ca-d5ad-4dd6-851d-9e43c3f7a159
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.theme_teaser_liftup
+    - field.field.media.image.field_media_image
+    - image.style.theme_teaser_liftup_image_small
+    - media.type.image
+  module:
+    - image
+id: media.image.theme_teaser_liftup
+targetEntityType: media
+bundle: image
+mode: theme_teaser_liftup
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: theme_teaser_liftup_image_small
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/conf/cmi/core.entity_view_display.taxonomy_term.theme.default.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.theme.default.yml
@@ -1,0 +1,28 @@
+uuid: 94eb5cf3-9cd4-4a6c-a637-22e1c4e1e2d9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.theme.field_liftup_image
+    - field.field.taxonomy_term.theme.field_paragraphs
+    - taxonomy.vocabulary.theme
+  module:
+    - entity_reference_revisions
+id: taxonomy_term.theme.default
+targetEntityType: taxonomy_term
+bundle: theme
+mode: default
+content:
+  field_paragraphs:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  description: true
+  field_liftup_image: true
+  langcode: true

--- a/conf/cmi/core.entity_view_display.taxonomy_term.theme.teaser.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.theme.teaser.yml
@@ -1,0 +1,27 @@
+uuid: 468ba715-4dfb-4fb1-b3c4-eef55085ca8c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.teaser
+    - field.field.taxonomy_term.theme.field_liftup_image
+    - field.field.taxonomy_term.theme.field_paragraphs
+    - taxonomy.vocabulary.theme
+id: taxonomy_term.theme.teaser
+targetEntityType: taxonomy_term
+bundle: theme
+mode: teaser
+content:
+  field_liftup_image:
+    type: entity_reference_entity_view
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      view_mode: theme_teaser_liftup
+      link: false
+    third_party_settings: {  }
+hidden:
+  description: true
+  field_paragraphs: true
+  langcode: true

--- a/conf/cmi/core.entity_view_mode.media.theme_teaser_liftup.yml
+++ b/conf/cmi/core.entity_view_mode.media.theme_teaser_liftup.yml
@@ -1,0 +1,10 @@
+uuid: a2047a26-35a8-4c16-95f5-0ec996faf18b
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.theme_teaser_liftup
+label: 'Theme Teaser Liftup'
+targetEntityType: media
+cache: true

--- a/conf/cmi/core.entity_view_mode.taxonomy_term.teaser.yml
+++ b/conf/cmi/core.entity_view_mode.taxonomy_term.teaser.yml
@@ -1,0 +1,10 @@
+uuid: baed684b-1eb5-44c5-8991-635939e86b60
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.teaser
+label: Teaser
+targetEntityType: taxonomy_term
+cache: true

--- a/conf/cmi/field.field.taxonomy_term.theme.field_liftup_image.yml
+++ b/conf/cmi/field.field.taxonomy_term.theme.field_liftup_image.yml
@@ -1,0 +1,28 @@
+uuid: e58919de-fcfb-408b-a28e-14fa2dc295a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_liftup_image
+    - media.type.image
+    - taxonomy.vocabulary.theme
+id: taxonomy_term.theme.field_liftup_image
+field_name: field_liftup_image
+entity_type: taxonomy_term
+bundle: theme
+label: 'Liftup image'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.taxonomy_term.theme.field_paragraphs.yml
+++ b/conf/cmi/field.field.taxonomy_term.theme.field_paragraphs.yml
@@ -1,0 +1,32 @@
+uuid: 55e42291-d857-4297-b83b-cb2382936144
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_paragraphs
+    - taxonomy.vocabulary.theme
+  module:
+    - entity_reference_revisions
+id: taxonomy_term.theme.field_paragraphs
+field_name: field_paragraphs
+entity_type: taxonomy_term
+bundle: theme
+label: Paragraphs
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 1
+    target_bundles: null
+    target_bundles_drag_drop:
+      media:
+        weight: 3
+        enabled: false
+      text:
+        weight: 4
+        enabled: false
+field_type: entity_reference_revisions

--- a/conf/cmi/field.storage.taxonomy_term.field_liftup_image.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_liftup_image.yml
@@ -1,0 +1,20 @@
+uuid: d987e388-c4c4-4233-91c8-03a1c1b295e1
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: taxonomy_term.field_liftup_image
+field_name: field_liftup_image
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.taxonomy_term.field_paragraphs.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_paragraphs.yml
@@ -1,0 +1,21 @@
+uuid: dc59653e-0fb9-4e06-8d53-f641dd9728a3
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+    - taxonomy
+id: taxonomy_term.field_paragraphs
+field_name: field_paragraphs
+entity_type: taxonomy_term
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/image.style.theme_teaser_liftup_image_small.yml
+++ b/conf/cmi/image.style.theme_teaser_liftup_image_small.yml
@@ -1,0 +1,17 @@
+uuid: c1654689-5210-4ed2-b2ed-9216b2c443b7
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: theme_teaser_liftup_image_small
+label: 'Theme Teaser Liftup Image Small'
+effects:
+  3dd1da00-fc81-48b9-89b7-bd53168d33ab:
+    uuid: 3dd1da00-fc81-48b9-89b7-bd53168d33ab
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 64
+      height: 64
+      crop_type: focal_point

--- a/conf/cmi/language/en/system.menu.main.yml
+++ b/conf/cmi/language/en/system.menu.main.yml
@@ -1,2 +1,0 @@
-label: 'Main navigation'
-description: 'Site section links'

--- a/conf/cmi/language/fi/field.field.taxonomy_term.theme.field_liftup_image.yml
+++ b/conf/cmi/language/fi/field.field.taxonomy_term.theme.field_liftup_image.yml
@@ -1,0 +1,1 @@
+label: Nostokuva

--- a/conf/cmi/language/fi/pathauto.pattern.theme_taxonomy.yml
+++ b/conf/cmi/language/fi/pathauto.pattern.theme_taxonomy.yml
@@ -1,0 +1,1 @@
+label: 'Teema taksonomia'

--- a/conf/cmi/pathauto.pattern.theme_taxonomy.yml
+++ b/conf/cmi/pathauto.pattern.theme_taxonomy.yml
@@ -1,0 +1,23 @@
+uuid: 59014a14-202e-454a-a182-49cf38120878
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - taxonomy
+id: theme_taxonomy
+label: 'Theme taxonomy'
+type: 'canonical_entities:taxonomy_term'
+pattern: '[term:name]'
+selection_criteria:
+  41f72425-3433-466f-a745-474e3725fb28:
+    id: 'entity_bundle:taxonomy_term'
+    bundles:
+      theme: theme
+    negate: false
+    context_mapping:
+      taxonomy_term: taxonomy_term
+    uuid: 41f72425-3433-466f-a745-474e3725fb28
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/public/themes/custom/suomidigi/src/js/moby.js
+++ b/public/themes/custom/suomidigi/src/js/moby.js
@@ -43,13 +43,13 @@ var Moby = function(options) {
   // add the overlay to the beginning of the body
   if (this.overlay === true) {
 
-    jQuery('body').prepend('<div class="moby-overlay ' + this.overlayClass + '" id="moby-overlay' + Moby.instances + '"></div>');
+    jQuery('a.skip-link').after('<div class="moby-overlay ' + this.overlayClass + '" id="moby-overlay' + Moby.instances + '"></div>');
     this.overlaySelector = jQuery('body').find('#moby-overlay' + Moby.instances);
     this.overlaySelector.on('click', this.closeMoby.bind(this));
   }
 
   // add moby markup
-  jQuery('body').prepend('<div class="moby moby-hidden ' + this.menuClass + '" id="moby' + Moby.instances + '"></div>');
+  jQuery('a.skip-link').after('<div class="moby moby-hidden ' + this.menuClass + '" id="moby' + Moby.instances + '"></div>');
   this.mobySelector = jQuery('body').find('#moby' + Moby.instances);
   this.cloneMenu();
 

--- a/public/themes/custom/suomidigi/src/scss/components/content/_page-title.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_page-title.scss
@@ -3,5 +3,12 @@
     color: $black;
     margin-top: $gutter;
     text-align: center;
+
+    &.page-title--alternative {
+      @include font-size(32px, 24px);
+      @include line-height(32px, 32px, 24px, 24px);
+      font-weight: normal;
+      text-transform: uppercase;
+    }
   }
 }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_theme-term.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_theme-term.scss
@@ -1,0 +1,29 @@
+.theme-term {
+  &__header {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    margin: $gutter auto $gutter*2 auto;
+    width: auto;
+  }
+
+  &__title {
+    .page-title--alternative {
+      margin: 0;
+    }
+  }
+
+  &__image {
+    margin-right: $gutter;
+
+    @include breakpoint($for-tablet-portrait-up) {
+      display: none;
+    }
+
+    img {
+      border-radius: 50%;
+      max-height: $gutter * 2;
+      max-width: $gutter * 2;
+    }
+  }
+}

--- a/public/themes/custom/suomidigi/src/scss/components/misc/_skip-link.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/misc/_skip-link.scss
@@ -1,0 +1,16 @@
+.skip-link.focusable {
+   &:focus {
+    background-color: $white;
+    border-radius: 0 0 10px 10px;
+    color: $blue;
+    display: block;
+    font-weight: bold;
+    min-width: 150px;
+    min-height: 20px;
+    left: calc(50% - 150px / 2);
+    padding: 5px 20px;
+    position: absolute;
+    text-align: center;
+    text-decoration: none;
+  }
+}

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-mobile.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-mobile.scss
@@ -104,3 +104,10 @@
     height: 1.3rem;
   }
 }
+
+@include breakpoint($for-tablet-portrait-up) {
+  .moby,
+  .moby-overlay {
+    display: none;
+  }
+}

--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -5,6 +5,7 @@
  * Functions to support theming in the Suomidigi theme.
  */
 
+use Drupal\media\Entity\Media;
 use Drupal\paragraphs\Entity\Paragraph;
 
 /**
@@ -30,9 +31,31 @@ function suomidigi_preprocess(&$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
+function suomidigi_preprocess_page_title(&$variables) {
+  $term = \Drupal::request()->attributes->get('taxonomy_term');
+  if (!empty($term) && $term->bundle() == 'theme') {
+    $variables['page_title_alternative'] = TRUE;
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function suomidigi_preprocess_block(&$variables) {
   if (isset($variables['elements']['#id'])) {
     $variables['content']['#attributes']['block_id'] = $variables['elements']['#id'];
+  }
+
+  if ($variables['plugin_id'] == 'page_title_block') {
+    $term = \Drupal::request()->attributes->get('taxonomy_term');
+    if (!empty($term) && $term->bundle() == 'theme') {
+      if ($term->hasField('field_liftup_image')) {
+        $media_id = $term->get('field_liftup_image')->first()->getValue()['target_id'];
+        $media = Media::load($media_id);
+        $build = \Drupal::entityTypeManager()->getViewBuilder('media')->view($media, 'theme_teaser_liftup');
+        $variables['content']['field_liftup_image'] = $build;
+      }
+    }
   }
 }
 

--- a/public/themes/custom/suomidigi/templates/blocks/block--page-title-block.html.twig
+++ b/public/themes/custom/suomidigi/templates/blocks/block--page-title-block.html.twig
@@ -33,7 +33,18 @@
     {% endif %}
     {{ title_suffix }}
     {% block content %}
-      {{ content }}
+      {% if content.field_liftup_image|render %}
+        <div class="theme-term__header">
+          <div class="theme-term__image">
+            {{ content.field_liftup_image|render }}
+          </div>
+          <div class="theme-term__title">
+            {{ content }}
+          </div>
+        </div>
+      {% else %}
+        {{ content }}
+      {% endif %}
     {% endblock %}
   {% endblock container_content %}
 {% endembed %}

--- a/public/themes/custom/suomidigi/templates/content/page-title.html.twig
+++ b/public/themes/custom/suomidigi/templates/content/page-title.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Theme override for page titles.
+ *
+ * Available variables:
+ * - title_attributes: HTML attributes for the page title element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title: The page title, for use in the actual content.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ */
+#}
+{%
+  set classes = [
+    'page-title',
+    page_title_alternative ? 'page-title--alternative',
+  ]
+%}
+{{ title_prefix }}
+{% if title %}
+  <h1{{ title_attributes.addClass(classes) }}>{{ title }}</h1>
+{% endif %}
+{{ title_suffix }}


### PR DESCRIPTION
To test: 
- `make fresh`
- Go to http://suomidigi.fi.docker.amazee.io/taxonomy/term/1/edit
   - Add liftup image of your choice
   - Add some paragraphs
- Go to http://suomidigi.fi.docker.amazee.io/taxonomy/term/1
   - Check that you get redirected to http://suomidigi.fi.docker.amazee.io/arkkitehtuuri
   - Check that the paragraphs works as they do elsewhere
   - Check that there's (unthemed) list of articles below the paragraphs
- Change the width of the browser to mobile width and check that the liftup image is shown next to the page title