### PR TITLE
SUOPA-227: Small Image Checkbox to Container 50/50 paragraph

### DIFF
--- a/conf/cmi/core.entity_form_display.paragraph.container.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.container.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.container.field_p_content
     - field.field.paragraph.container.field_p_reverse
+    - field.field.paragraph.container.field_p_small_image
     - paragraphs.paragraphs_type.container
   module:
     - paragraphs
@@ -34,6 +35,13 @@ content:
     region: content
   field_p_reverse:
     weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_p_small_image:
+    weight: 2
     settings:
       display_label: true
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.paragraph.container.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.container.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.container.field_p_content
     - field.field.paragraph.container.field_p_reverse
+    - field.field.paragraph.container.field_p_small_image
     - paragraphs.paragraphs_type.container
   module:
     - entity_reference_revisions
@@ -24,6 +25,16 @@ content:
     region: content
   field_p_reverse:
     weight: 1
+    label: hidden
+    settings:
+      format: boolean
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_p_small_image:
+    weight: 2
     label: hidden
     settings:
       format: boolean

--- a/conf/cmi/field.field.paragraph.container.field_p_small_image.yml
+++ b/conf/cmi/field.field.paragraph.container.field_p_small_image.yml
@@ -1,0 +1,21 @@
+uuid: 8c8cb4c3-33d8-48b9-991d-eabef2a79da6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_small_image
+    - paragraphs.paragraphs_type.container
+id: paragraph.container.field_p_small_image
+field_name: field_p_small_image
+entity_type: paragraph
+bundle: container
+label: 'Small Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.storage.paragraph.field_p_small_image.yml
+++ b/conf/cmi/field.storage.paragraph.field_p_small_image.yml
@@ -1,0 +1,18 @@
+uuid: 3ce50e1c-7649-42f0-9efc-af732c410a47
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_p_small_image
+field_name: field_p_small_image
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--container.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--container.scss
@@ -25,4 +25,12 @@
       }
     }
   }
+
+  &.paragraph--small-image {
+    .paragraph--media {
+      @include breakpoint($for-tablet-portrait-up) {
+        width: calc(100% / 3);
+      }
+    }
+  }
 }

--- a/public/themes/custom/suomidigi/templates/paragraph/paragraph--container.html.twig
+++ b/public/themes/custom/suomidigi/templates/paragraph/paragraph--container.html.twig
@@ -2,14 +2,19 @@
 
 {% block paragraph %}
   {% set reverse = content.field_p_reverse['0']['#markup'] %}
+  {% set small_image = content.field_p_small_image['0']['#markup'] %}
 
   {% if reverse is same as(1) %}
     {% set classes = classes|merge(['paragraph--reverse']) %}
   {% endif %}
 
+  {% if small_image is same as(1) %}
+    {% set classes = classes|merge(['paragraph--small-image']) %}
+  {% endif %}
+
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-  {{ content.field_p_content }}
+      {{ content.field_p_content }}
     {% endblock %}
   </div>
 {% endblock paragraph %}


### PR DESCRIPTION
1. `make fresh`
2. Create a node with possibility to add ""Container 50/50" paragraph
3. Test that the "Small Image" checkbox works

![Screenshot_2019-06-06 Testi Suomidigi](https://user-images.githubusercontent.com/22739952/59016782-b8268380-884a-11e9-9424-484aa90c1314.jpg)
