### PR TITLE
SUOPA-290 Logic to disable checkboxes on demand

### DIFF
--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -30,6 +30,12 @@ display:
         type: tag
       query:
         type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_comment: ''
+          query_tags: {  }
       exposed_form:
         type: basic
         options:

--- a/public/modules/custom/suopa_editorial/assets/css/editor_enhancements.css
+++ b/public/modules/custom/suopa_editorial/assets/css/editor_enhancements.css
@@ -1,0 +1,3 @@
+.is-disabled {
+  opacity: 0.4;
+}

--- a/public/modules/custom/suopa_editorial/assets/js/disable-sibling-checkbox.js
+++ b/public/modules/custom/suopa_editorial/assets/js/disable-sibling-checkbox.js
@@ -1,0 +1,55 @@
+($ => {
+  // Make sibling checkboxes disabled if one is enabled.
+  function handleDisabling(element) {
+    const id = element;
+    const wrapper = ".is-disableable--wrapper";
+
+    if ($(id).is(":checked")) {
+      $(id)
+        .closest(wrapper)
+        .siblings(wrapper)
+        .addClass("is-disabled")
+        .find(".is-disableable")
+        .attr("disabled", true);
+    } else {
+      $(id)
+        .closest(wrapper)
+        .siblings(wrapper)
+        .removeClass("is-disabled")
+        .find(".is-disableable")
+        .removeAttr("disabled");
+    }
+  }
+
+  // Check initial status and disable necessary checkboxes.
+  function initializeCheckboxes() {
+    const isDisableable = $("input.is-disableable");
+
+    isDisableable.each((index, value) => {
+      if ($(value).is(":checked")) {
+        const id = `#${$(value).attr("id")}`;
+        const wrapper = ".is-disableable--wrapper";
+        const item = $(id)
+          .closest(wrapper)
+          .siblings(wrapper);
+
+        if (!item.hasClass("is-disabled")) {
+          item
+            .addClass("is-disabled")
+            .find(".is-disableable")
+            .attr("disabled", true);
+        }
+      }
+    });
+
+    isDisableable.on("change", value => {
+      handleDisabling(value.currentTarget);
+    });
+  }
+
+  initializeCheckboxes();
+
+  $(document).ajaxComplete(() => {
+    initializeCheckboxes();
+  });
+})(jQuery);

--- a/public/modules/custom/suopa_editorial/suopa_editorial.libraries.yml
+++ b/public/modules/custom/suopa_editorial/suopa_editorial.libraries.yml
@@ -4,6 +4,15 @@ blog-tag-list-hidden:
   dependencies:
     - core/jquery
 
+disable-sibling-checkbox:
+  js:
+    assets/js/disable-sibling-checkbox.js: {}
+  css:
+    theme:
+      assets/css/editor_enhancements.css: {}
+  dependencies:
+    - core/jquery
+
 paragraph-drag-n-drop:
   js:
     assets/js/paragraph_drag-n-drop.js: {}

--- a/public/modules/custom/suopa_editorial/suopa_editorial.module
+++ b/public/modules/custom/suopa_editorial/suopa_editorial.module
@@ -15,6 +15,7 @@ use Drupal\views\ViewExecutable;
 function suopa_editorial_form_alter(&$form, $form_state) {
   suopa_editorial_modify_article_publishing_info($form, $form_state);
   suopa_editorial_enable_drag_and_drop($form, $form_state);
+  suopa_editorial_disable_sibling_checkbox($form, $form_state);
 }
 
 /**
@@ -66,6 +67,30 @@ function suopa_editorial_enable_drag_and_drop(&$form, $form_state) {
 }
 
 /**
+ * Disable sibling checkbox if the current has been clicked.
+ *
+ * @param array $form
+ *   Form.
+ * @param array $form_state
+ *   Form state.
+ */
+function suopa_editorial_disable_sibling_checkbox(&$form, $form_state) {
+  $allowedIds = [
+    'node_article_edit_form',
+    'node_article_form',
+    'node_landing_page_edit_form',
+    'node_landing_page_form',
+    'taxonomy_term_theme_form'
+  ];
+
+  if (!in_array($form['#form_id'], $allowedIds)) {
+    return;
+  }
+
+  $form['#attached']['library'][] = 'suopa_editorial/disable-sibling-checkbox';
+}
+
+/**
  * Implements hook_views_pre_render().
  *
  * Modify media entity browser image width to suit smaller screens.
@@ -75,5 +100,53 @@ function suopa_editorial_enable_drag_and_drop(&$form, $form_state) {
 function suopa_editorial_views_pre_render(ViewExecutable $view) {
   if (isset($view) && $view->id() === 'media_entity_browser') {
     $view->element['#attached']['library'][] = 'suopa_editorial/media-entity-browser';
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Add custom classes to input__checkbox.
+ */
+function suopa_editorial_preprocess_input__checkbox(&$variables) {
+  if (!isset($variables['element']['#parents'])) {
+    return;
+  }
+
+  $fields = [
+    'field_p_small_image',
+    'field_p_content_50_50',
+  ];
+
+  foreach ($fields as $field) {
+    if (in_array($field, $variables['element']['#parents'], TRUE)) {
+      $variables['attributes']['class'][] = 'is-disableable';
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Add custom classes to input__checkbox.
+ */
+function suopa_editorial_preprocess_container(&$variables) {
+  if (!isset($variables['element']['#parents'])) {
+    return;
+  }
+
+  $fields = [
+    'field--name-field-p-small-image',
+    'field--name-field-p-content-50-50',
+  ];
+
+  foreach ($fields as $field) {
+    if (
+      isset($variables['attributes']['class']) &&
+      is_array($variables['attributes']['class']) &&
+      in_array($field, $variables['attributes']['class'])
+    ) {
+      $variables['attributes']['class'] = 'is-disableable--wrapper';
+    }
   }
 }

--- a/public/modules/custom/suopa_editorial/suopa_editorial.module
+++ b/public/modules/custom/suopa_editorial/suopa_editorial.module
@@ -128,7 +128,7 @@ function suopa_editorial_preprocess_input__checkbox(&$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  *
- * Add custom classes to input__checkbox.
+ * Add custom classes to container.
  */
 function suopa_editorial_preprocess_container(&$variables) {
   if (!isset($variables['element']['#parents'])) {


### PR DESCRIPTION
To test:
- `make fresh`
- Go and edit some landing page or article which has container 50/50 paragraph
- Make sure you cannot select Small image and Content 50/50 checkboxes at the same time.
- Test also with multiple container 50/50 paragraphs.