### PR TITLE
Suopa 449 legislation unlimited attachments

### DIFF
--- a/conf/cmi/core.entity_form_display.node.legislation_card.default.yml
+++ b/conf/cmi/core.entity_form_display.node.legislation_card.default.yml
@@ -37,7 +37,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
     region: content
   field_ingress:
@@ -65,7 +65,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: legislation_attachment
     third_party_settings: {  }
     region: content
   field_legislation_section:

--- a/conf/cmi/field.field.node.legislation_card.field_attachments.yml
+++ b/conf/cmi/field.field.node.legislation_card.field_attachments.yml
@@ -14,7 +14,7 @@ entity_type: node
 bundle: legislation_card
 label: Attachments
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -63,6 +63,12 @@ settings:
         enabled: false
       liftup_prominent:
         weight: 27
+        enabled: false
+      legislation_cards:
+        weight: 27
+        enabled: false
+      legislation_link:
+        weight: 28
         enabled: false
       link:
         weight: 28

--- a/conf/cmi/field.storage.node.field_attachments.yml
+++ b/conf/cmi/field.storage.node.field_attachments.yml
@@ -14,7 +14,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: 4
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_local-tasks.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_local-tasks.scss
@@ -16,6 +16,7 @@
 
     a {
       @include button;
+      background-color: $white;
 
       &.is-active {
         background-color: $black;

--- a/public/themes/custom/suomidigi/src/scss/layout/_page-header.scss
+++ b/public/themes/custom/suomidigi/src/scss/layout/_page-header.scss
@@ -27,6 +27,7 @@
     align-items: center;
     display: flex;
     margin: 0;
+    position: relative;
 
     @include breakpoint(0, $for-tablet-portrait-up) {
       width: 100%;

--- a/public/themes/custom/suomidigi/src/scss/layout/_page.scss
+++ b/public/themes/custom/suomidigi/src/scss/layout/_page.scss
@@ -23,3 +23,28 @@
     margin-right: $gutter * 2;
   }
 }
+
+.page-flag {
+  &.is-unpublished {
+    background: $red;
+    border-radius: $gutter 0 0 $gutter;
+    bottom: -23px;
+    color: $white;
+    font-weight: 600;
+    font-size: 12px;
+    padding: $gutter / 4 $gutter;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    text-transform: uppercase;
+
+    @include breakpoint($for-tablet-portrait-up) {
+      border-radius: 0 0 $gutter $gutter;
+      bottom: -31px;
+      padding: 0 $gutter $gutter / 4 $gutter;
+    }
+    @include breakpoint($for-desktop-up) {
+      right: calc(-120px - #{$gutter});
+    }
+  }
+}

--- a/public/themes/custom/suomidigi/templates/content/node--legislation-card--expanding-panels.html.twig
+++ b/public/themes/custom/suomidigi/templates/content/node--legislation-card--expanding-panels.html.twig
@@ -17,6 +17,7 @@
 %}
 
 <article{{ attributes.addClass(classes) }}>
+  {{ title_suffix.contextual_links }}
   <div class="legislation-card__header">
     <div class="legislation-card__title">
       {{ label }}

--- a/public/themes/custom/suomidigi/templates/content/node--legislation-card--full.html.twig
+++ b/public/themes/custom/suomidigi/templates/content/node--legislation-card--full.html.twig
@@ -83,6 +83,7 @@
 %}
 
 <article{{ attributes.addClass(classes) }}>
+  {{ title_suffix.contextual_links }}
   <div class="legislation-card__header">
     <div class="legislation-card__title">
       {{ label }}

--- a/public/themes/custom/suomidigi/templates/layout/page.html.twig
+++ b/public/themes/custom/suomidigi/templates/layout/page.html.twig
@@ -46,6 +46,7 @@
 {% set page_content_classes = [
   'page-content',
   node ? 'page-content--node',
+  not node.isPublished() ? 'page-content--unpublished',
 ]
 %}
 
@@ -76,6 +77,9 @@
                 {{ 'Menu'|t }}
               {% endif %}
             </button>
+            {% if not node.isPublished() %}
+              <div class="page-flag is-unpublished">{{ 'Unpublished'|t }}</div>
+            {% endif %}
           </div>
         {% endif %}
       </header>


### PR DESCRIPTION
To test: 
- `make fresh`
- Go to: http://suomidigi.fi.docker.amazee.io/node/add/legislation_card
   - Test that you can add Legislation cards without attachments
- Go to: http://suomidigi.fi.docker.amazee.io/node/123/edit
   - Test that you can add more than four (4) attachments to Legislation card attachments paragraph

Bonus:
- Go to f.e. http://suomidigi.fi.docker.amazee.io/node/90 and check that there's a new indicator what defines that the node is unpublished.
