### PR TITLE
SUOPA-448 Legislation card translations

### DIFF
--- a/conf/cmi/core.base_field_override.paragraph.legislation_attachment.created.yml
+++ b/conf/cmi/core.base_field_override.paragraph.legislation_attachment.created.yml
@@ -1,0 +1,18 @@
+uuid: 9e8d5843-4c40-4aeb-84ac-7e2558b921fd
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_attachment
+id: paragraph.legislation_attachment.created
+field_name: created
+entity_type: paragraph
+bundle: legislation_attachment
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/conf/cmi/core.base_field_override.paragraph.legislation_attachment.status.yml
+++ b/conf/cmi/core.base_field_override.paragraph.legislation_attachment.status.yml
@@ -1,0 +1,22 @@
+uuid: 384bab6d-50f7-4990-876f-5ef8122f3a9c
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_attachment
+id: paragraph.legislation_attachment.status
+field_name: status
+entity_type: paragraph
+bundle: legislation_attachment
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/core.base_field_override.paragraph.legislation_cards.created.yml
+++ b/conf/cmi/core.base_field_override.paragraph.legislation_cards.created.yml
@@ -1,0 +1,18 @@
+uuid: 5132e583-ca34-4785-9ab6-c7b5e9180209
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_cards
+id: paragraph.legislation_cards.created
+field_name: created
+entity_type: paragraph
+bundle: legislation_cards
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/conf/cmi/core.base_field_override.paragraph.legislation_cards.status.yml
+++ b/conf/cmi/core.base_field_override.paragraph.legislation_cards.status.yml
@@ -1,0 +1,22 @@
+uuid: 3288980f-94e4-48db-8b28-cca2b32938a1
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_cards
+id: paragraph.legislation_cards.status
+field_name: status
+entity_type: paragraph
+bundle: legislation_cards
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/core.base_field_override.paragraph.legislation_link.created.yml
+++ b/conf/cmi/core.base_field_override.paragraph.legislation_link.created.yml
@@ -1,0 +1,18 @@
+uuid: df4900e0-7a62-42ed-bd92-4dfc5a44814d
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_link
+id: paragraph.legislation_link.created
+field_name: created
+entity_type: paragraph
+bundle: legislation_link
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/conf/cmi/core.base_field_override.paragraph.legislation_link.status.yml
+++ b/conf/cmi/core.base_field_override.paragraph.legislation_link.status.yml
@@ -1,0 +1,22 @@
+uuid: 464e2879-4243-42f9-9204-c18188f86861
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_link
+id: paragraph.legislation_link.status
+field_name: status
+entity_type: paragraph
+bundle: legislation_link
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/core.base_field_override.paragraph.liftup_prominent.created.yml
+++ b/conf/cmi/core.base_field_override.paragraph.liftup_prominent.created.yml
@@ -1,0 +1,18 @@
+uuid: db203875-3396-4a58-9ac4-54385ea70a0c
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.liftup_prominent
+id: paragraph.liftup_prominent.created
+field_name: created
+entity_type: paragraph
+bundle: liftup_prominent
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/conf/cmi/core.base_field_override.paragraph.liftup_prominent.status.yml
+++ b/conf/cmi/core.base_field_override.paragraph.liftup_prominent.status.yml
@@ -1,0 +1,22 @@
+uuid: ab6e0bf5-a9e3-40f1-9461-66bf0397dc34
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.liftup_prominent
+id: paragraph.liftup_prominent.status
+field_name: status
+entity_type: paragraph
+bundle: liftup_prominent
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/core.entity_form_display.node.legislation_card.default.yml
+++ b/conf/cmi/core.entity_form_display.node.legislation_card.default.yml
@@ -37,7 +37,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
     region: content
   field_ingress:
@@ -65,7 +65,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: legislation_attachment
     third_party_settings: {  }
     region: content
   field_legislation_section:

--- a/conf/cmi/field.field.node.legislation_card.field_attachments.yml
+++ b/conf/cmi/field.field.node.legislation_card.field_attachments.yml
@@ -14,7 +14,7 @@ entity_type: node
 bundle: legislation_card
 label: Attachments
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -63,6 +63,12 @@ settings:
         enabled: false
       liftup_prominent:
         weight: 27
+        enabled: false
+      legislation_cards:
+        weight: 27
+        enabled: false
+      legislation_link:
+        weight: 28
         enabled: false
       link:
         weight: 28

--- a/conf/cmi/field.field.paragraph.legislation_attachment.field_legislation_attachment.yml
+++ b/conf/cmi/field.field.paragraph.legislation_attachment.field_legislation_attachment.yml
@@ -14,7 +14,7 @@ bundle: legislation_attachment
 label: 'Attachment File'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.paragraph.legislation_attachment.field_legislation_colour.yml
+++ b/conf/cmi/field.field.paragraph.legislation_attachment.field_legislation_colour.yml
@@ -14,7 +14,7 @@ bundle: legislation_attachment
 label: 'Legislation Colour'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.paragraph.legislation_cards.field_legislation_section.yml
+++ b/conf/cmi/field.field.paragraph.legislation_cards.field_legislation_section.yml
@@ -13,7 +13,7 @@ bundle: legislation_cards
 label: 'Legislation section'
 description: 'The section of the legislation from which the Legislation Cards are shown.'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.paragraph.legislation_link.field_link_description.yml
+++ b/conf/cmi/field.field.paragraph.legislation_link.field_link_description.yml
@@ -12,7 +12,7 @@ bundle: legislation_link
 label: 'Link Description'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.paragraph.legislation_link.field_link_destination.yml
+++ b/conf/cmi/field.field.paragraph.legislation_link.field_link_destination.yml
@@ -12,7 +12,7 @@ bundle: legislation_link
 label: 'Link Destination'
 description: 'For example, <em>Finlex.fi</em>'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.storage.node.field_attachments.yml
+++ b/conf/cmi/field.storage.node.field_attachments.yml
@@ -14,7 +14,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: 4
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/conf/cmi/language.content_settings.block_content.cta_banner.yml
+++ b/conf/cmi/language.content_settings.block_content.cta_banner.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: block_content.cta_banner
 target_entity_type_id: block_content
 target_bundle: cta_banner

--- a/conf/cmi/language.content_settings.file.file.yml
+++ b/conf/cmi/language.content_settings.file.file.yml
@@ -7,5 +7,5 @@ dependencies:
 id: file.file
 target_entity_type_id: file
 target_bundle: file
-default_langcode: site_default
+default_langcode: fi
 language_alterable: false

--- a/conf/cmi/language.content_settings.node.core_content.yml
+++ b/conf/cmi/language.content_settings.node.core_content.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.core_content
 target_entity_type_id: node
 target_bundle: core_content

--- a/conf/cmi/language.content_settings.node.legislation_card.yml
+++ b/conf/cmi/language.content_settings.node.legislation_card.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.legislation_card
 target_entity_type_id: node
 target_bundle: legislation_card

--- a/conf/cmi/language.content_settings.node.legislation_collection_page.yml
+++ b/conf/cmi/language.content_settings.node.legislation_collection_page.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.legislation_collection_page
 target_entity_type_id: node
 target_bundle: legislation_collection_page

--- a/conf/cmi/language.content_settings.node.webform.yml
+++ b/conf/cmi/language.content_settings.node.webform.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.webform
 target_entity_type_id: node
 target_bundle: webform

--- a/conf/cmi/language.content_settings.paragraph.legislation_attachment.yml
+++ b/conf/cmi/language.content_settings.paragraph.legislation_attachment.yml
@@ -1,0 +1,18 @@
+uuid: 370a5ff3-ac9d-4ad8-a88c-4e19ad905b60
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_attachment
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.legislation_attachment
+target_entity_type_id: paragraph
+target_bundle: legislation_attachment
+default_langcode: fi
+language_alterable: true

--- a/conf/cmi/language.content_settings.paragraph.legislation_cards.yml
+++ b/conf/cmi/language.content_settings.paragraph.legislation_cards.yml
@@ -1,0 +1,18 @@
+uuid: 5416cd8b-a744-4c89-8684-d272a7663e69
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_cards
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.legislation_cards
+target_entity_type_id: paragraph
+target_bundle: legislation_cards
+default_langcode: fi
+language_alterable: true

--- a/conf/cmi/language.content_settings.paragraph.legislation_link.yml
+++ b/conf/cmi/language.content_settings.paragraph.legislation_link.yml
@@ -1,0 +1,18 @@
+uuid: 513e1c2f-0d94-4f17-8342-1acdf7e8037f
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.legislation_link
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.legislation_link
+target_entity_type_id: paragraph
+target_bundle: legislation_link
+default_langcode: fi
+language_alterable: true

--- a/conf/cmi/language.content_settings.paragraph.liftup_prominent.yml
+++ b/conf/cmi/language.content_settings.paragraph.liftup_prominent.yml
@@ -1,0 +1,18 @@
+uuid: c540b365-7d65-4e83-9fe7-730d6c1889bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.liftup_prominent
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.liftup_prominent
+target_entity_type_id: paragraph
+target_bundle: liftup_prominent
+default_langcode: fi
+language_alterable: true

--- a/conf/cmi/language.content_settings.taxonomy_term.core_content_type.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.core_content_type.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.core_content_type
 target_entity_type_id: taxonomy_term
 target_bundle: core_content_type

--- a/conf/cmi/language.content_settings.taxonomy_term.legislation.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.legislation.yml
@@ -4,8 +4,15 @@ status: true
 dependencies:
   config:
     - taxonomy.vocabulary.legislation
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.legislation
 target_entity_type_id: taxonomy_term
 target_bundle: legislation
 default_langcode: fi
-language_alterable: false
+language_alterable: true

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_attachment.created.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_attachment.created.yml
@@ -1,0 +1,2 @@
+label: Luotu
+description: 'Aika jolloin paragraafi luotiin.'

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_attachment.status.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_attachment.status.yml
@@ -1,0 +1,5 @@
+label: Julkaistu
+description: ''
+settings:
+  on_label: Julkaistu
+  off_label: Julkaisematon

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_cards.created.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_cards.created.yml
@@ -1,0 +1,2 @@
+label: Luotu
+description: 'Aika jolloin paragraafi luotiin.'

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_cards.status.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_cards.status.yml
@@ -1,0 +1,5 @@
+label: Julkaistu
+description: ''
+settings:
+  on_label: Julkaistu
+  off_label: Julkaisematon

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_link.created.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_link.created.yml
@@ -1,0 +1,2 @@
+label: Luotu
+description: 'Aika jolloin paragraafi luotiin.'

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_link.status.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.legislation_link.status.yml
@@ -1,0 +1,5 @@
+label: Julkaistu
+description: ''
+settings:
+  on_label: Julkaistu
+  off_label: Julkaisematon

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.liftup_prominent.created.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.liftup_prominent.created.yml
@@ -1,0 +1,2 @@
+label: Luotu
+description: 'Aika jolloin paragraafi luotiin.'

--- a/conf/cmi/language/fi/core.base_field_override.paragraph.liftup_prominent.status.yml
+++ b/conf/cmi/language/fi/core.base_field_override.paragraph.liftup_prominent.status.yml
@@ -1,0 +1,5 @@
+label: Julkaistu
+description: ''
+settings:
+  on_label: Julkaistu
+  off_label: Julkaisematon

--- a/conf/cmi/language/fi/field.field.paragraph.legislation_link.field_link_destination.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.legislation_link.field_link_destination.yml
@@ -2,7 +2,5 @@ label: 'Linkin kohde'
 description: 'Esimerkiksi, <em>Finlex.fi</em>'
 required: true
 translatable: false
-default_value: {  }
 default_value_callback: ''
-settings: {  }
 field_type: string

--- a/conf/cmi/language/fi/taxonomy.vocabulary.legislation.yml
+++ b/conf/cmi/language/fi/taxonomy.vocabulary.legislation.yml
@@ -1,0 +1,2 @@
+name: Lainsäädäntö
+description: 'Puurakenteinen taksonomia lakikoontisivujen ja lakikorttien tueksi'

--- a/conf/cmi/taxonomy.vocabulary.legislation.yml
+++ b/conf/cmi/taxonomy.vocabulary.legislation.yml
@@ -4,5 +4,5 @@ status: true
 dependencies: {  }
 name: Legislation
 vid: legislation
-description: ''
+description: 'The tree structure for legislation cards and collections'
 weight: 0

--- a/public/modules/custom/suopa_legislations/suopa_legislations.module
+++ b/public/modules/custom/suopa_legislations/suopa_legislations.module
@@ -9,6 +9,7 @@ use Drupal\block\Entity\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\Core\TypedData\TranslationStatusInterface;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -22,6 +23,8 @@ function suopa_legislations_preprocess_paragraph(&$variables) {
   if ($paragraph->getType() == 'legislation_cards') {
     // Get selected terms (legislation sections) from the paragraph.
     $terms = $paragraph->get('field_legislation_section')->referencedEntities();
+    $langcode = Drupal::languageManager()->getCurrentLanguage()->getId();
+
     foreach ($terms as $term) {
       // Fetch all potential legislation card collections from the selected
       // terms. Note that all the child terms are not necessarily collections!
@@ -29,15 +32,22 @@ function suopa_legislations_preprocess_paragraph(&$variables) {
         ->getStorage('taxonomy_term')
         ->getChildren($term);
       foreach ($cardCollectionTerms as $collectionTerm) {
-        $cards = suopa_legislations_get_related_legislation_cards($collectionTerm);
+        $cards = suopa_legislations_get_related_legislation_cards($collectionTerm, $langcode);
         if (!count($cards)) {
           continue;
+        }
+
+        if ($collectionTerm->hasTranslation($langcode)) {
+          $collectionLabel = $collectionTerm->getTranslation($langcode)->getName();
+        }
+        else {
+          $collectionLabel = $collectionTerm->getName();
         }
 
         $renderedLegislationCollection = [
           'title' => [
             '#theme' => 'suopa_legislations_collection_label',
-            '#collection_label' => $collectionTerm->getName(),
+            '#collection_label' => $collectionLabel,
           ],
           'cards' => [
             '#theme' => 'suopa_legislations_collection',
@@ -61,6 +71,8 @@ function suopa_legislations_preprocess_paragraph(&$variables) {
  *
  * @param \Drupal\taxonomy\Entity\Term $collection
  *   The collection term to fetch the cards from.
+ * @param string $langcode
+ *   The current language id.
  *
  * @return array
  *   Return found legislation cards.
@@ -70,7 +82,7 @@ function suopa_legislations_preprocess_paragraph(&$variables) {
  * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
  *   Thrown if the storage handler couldn't be loaded.
  */
-function suopa_legislations_get_related_legislation_cards(Term $collection) {
+function suopa_legislations_get_related_legislation_cards(Term $collection, $langcode) {
   $cards = [];
 
   $ids = Drupal::entityQuery('node')
@@ -87,7 +99,9 @@ function suopa_legislations_get_related_legislation_cards(Term $collection) {
 
   foreach ($ids as $id) {
     $node = $nodeStorage->load($id);
-    $cards[] = $nodeRendered->view($node, $view_mode);
+    if ($node->hasTranslation($langcode)) {
+      $cards[] = $nodeRendered->view($node, $view_mode, $langcode);
+    }
   }
 
   return $cards;
@@ -124,4 +138,96 @@ function suopa_legislations_block_access(Block $block, $operation) {
   }
 
   return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ *
+ * When creating translation of a paragraph with file entity, clear the default
+ * value of the file upload field from form. Set the original filename to file
+ * upload field prefix as a reminder of the original file.
+ *
+ * Use the functionality for legislation attachments for now.
+ */
+function suopa_legislations_field_widget_entity_reference_paragraphs_form_alter(&$element, &$form_state, $context) {
+
+  // Allowed paragraph types.
+  $paragraph_types = [
+    'legislation_attachment',
+  ];
+
+  // Handle only entity reference paragraphs.
+  if ($context['widget']->getPluginId() !== 'entity_reference_paragraphs') {
+    return;
+  }
+
+  // Handle only allowed paragraph types.
+  if (!suopa_legislations_check_paragraph_types(
+    $paragraph_types,
+    $context['widget']->getAllowedTypes())
+  ) {
+    return;
+  }
+
+  // Handle only translations.
+  if ($form_state->getFormObject()->getEntity()->get('default_langcode')->value) {
+    return;
+  }
+
+  // Get translation status of the node.
+  $entity = $form_state->getFormObject()->getEntity();
+  $current_language = $entity->langcode->value;
+  $translation_status = $entity->getTranslationStatus($current_language);
+
+  // Return if translation status is not 2; Translation being created.
+  if ($translation_status !== TranslationStatusInterface::TRANSLATION_CREATED) {
+    return;
+  }
+
+  // Handle only legislation attachment field for now.
+  if (isset($element['subform']['field_legislation_attachment'])) {
+    $widgets = &$element['subform']['field_legislation_attachment']['widget'];
+
+    // Get field widget default values filename and set it as field widget
+    // description. Remove the default value from the widget to reduce confusion
+    // when translating file entities.
+    foreach ($widgets as &$widget) {
+      if (
+        isset($widget['#default_value']) &&
+        !empty($widget['#default_value']['target_id'])
+      ) {
+        $filename = Drupal::entityTypeManager()
+          ->getStorage('file')
+          ->load($widget['#default_value']['target_id'])
+          ->getFilename();
+
+        unset($widget['#default_value']);
+        $widget['#description'] = '<em>' . t(
+          'Filename in original language: @filename',
+          ['@filename' => $filename]
+        ) . '</em>';
+      }
+    }
+  }
+}
+
+/**
+ * Helper function to check for acceptable paragraph type.
+ *
+ * @param array $indexes
+ *   An array of possible array keys.
+ * @param array $types
+ *   An array of paragraph types.
+ *
+ * @return bool
+ *   Returns true or false.
+ */
+function suopa_legislations_check_paragraph_types(array $indexes, array $types) {
+  foreach ($indexes as $index) {
+    if (array_key_exists($index, $types)) {
+      return TRUE;
+    }
+    continue;
+  }
+  return FALSE;
 }

--- a/public/themes/custom/suomidigi/src/js/searchToggle.js
+++ b/public/themes/custom/suomidigi/src/js/searchToggle.js
@@ -18,12 +18,15 @@
         }
       });
 
-      searchToggleButton.addEventListener("click", (e) => {
-        e.stopImmediatePropagation();
+      function handleInteraction(e) {
+        e.preventDefault();
         const searchFormInput = document.getElementById("search");
         searchFormParentElement.classList.toggle("is-hidden");
         searchFormInput.focus();
-      });
+      }
+
+      searchToggleButton.addEventListener('touchstart', handleInteraction);
+      searchToggleButton.addEventListener('click', handleInteraction);
     }
   }
 })(jQuery, Drupal);

--- a/public/themes/custom/suomidigi/src/scss/components/content/_legislation-card.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_legislation-card.scss
@@ -3,6 +3,11 @@
   border: 1px solid $legislation-gray;
   padding: $gutter;
 
+  > .contextual {
+    right: -20px;
+    top: 12px;
+  }
+
   &__title {
     @include font-size(18px);
     @include line-height(18px, 18px);

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_local-tasks.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_local-tasks.scss
@@ -16,6 +16,7 @@
 
     a {
       @include button;
+      background-color: $white;
 
       &.is-active {
         background-color: $black;

--- a/public/themes/custom/suomidigi/src/scss/layout/_page-header.scss
+++ b/public/themes/custom/suomidigi/src/scss/layout/_page-header.scss
@@ -27,6 +27,7 @@
     align-items: center;
     display: flex;
     margin: 0;
+    position: relative;
 
     @include breakpoint(0, $for-tablet-portrait-up) {
       width: 100%;

--- a/public/themes/custom/suomidigi/src/scss/layout/_page.scss
+++ b/public/themes/custom/suomidigi/src/scss/layout/_page.scss
@@ -23,3 +23,28 @@
     margin-right: $gutter * 2;
   }
 }
+
+.page-flag {
+  &.is-unpublished {
+    background: $red;
+    border-radius: $gutter 0 0 $gutter;
+    bottom: -23px;
+    color: $white;
+    font-weight: 600;
+    font-size: 12px;
+    padding: $gutter / 4 $gutter;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    text-transform: uppercase;
+
+    @include breakpoint($for-tablet-portrait-up) {
+      border-radius: 0 0 $gutter $gutter;
+      bottom: -31px;
+      padding: 0 $gutter $gutter / 4 $gutter;
+    }
+    @include breakpoint($for-desktop-up) {
+      right: calc(-120px - #{$gutter});
+    }
+  }
+}

--- a/public/themes/custom/suomidigi/templates/content/node--legislation-card--expanding-panels.html.twig
+++ b/public/themes/custom/suomidigi/templates/content/node--legislation-card--expanding-panels.html.twig
@@ -17,6 +17,7 @@
 %}
 
 <article{{ attributes.addClass(classes) }}>
+  {{ title_suffix.contextual_links }}
   <div class="legislation-card__header">
     <div class="legislation-card__title">
       {{ label }}

--- a/public/themes/custom/suomidigi/templates/content/node--legislation-card--full.html.twig
+++ b/public/themes/custom/suomidigi/templates/content/node--legislation-card--full.html.twig
@@ -83,6 +83,7 @@
 %}
 
 <article{{ attributes.addClass(classes) }}>
+  {{ title_suffix.contextual_links }}
   <div class="legislation-card__header">
     <div class="legislation-card__title">
       {{ label }}

--- a/public/themes/custom/suomidigi/templates/layout/page.html.twig
+++ b/public/themes/custom/suomidigi/templates/layout/page.html.twig
@@ -46,6 +46,7 @@
 {% set page_content_classes = [
   'page-content',
   node ? 'page-content--node',
+  not node.isPublished() ? 'page-content--unpublished',
 ]
 %}
 
@@ -76,6 +77,9 @@
                 {{ 'Menu'|t }}
               {% endif %}
             </button>
+            {% if not node.isPublished() %}
+              <div class="page-flag is-unpublished">{{ 'Unpublished'|t }}</div>
+            {% endif %}
           </div>
         {% endif %}
       </header>

--- a/public/themes/custom/suomidigi/templates/layout/page.html.twig
+++ b/public/themes/custom/suomidigi/templates/layout/page.html.twig
@@ -77,7 +77,7 @@
                 {{ 'Menu'|t }}
               {% endif %}
             </button>
-            {% if not node.isPublished() %}
+            {% if not node.isPublished() and logged_in %}
               <div class="page-flag is-unpublished">{{ 'Unpublished'|t }}</div>
             {% endif %}
           </div>


### PR DESCRIPTION
How to test:
- `make fresh`
- Go to http://suomidigi.fi.docker.amazee.io/node/125
- Translate the first legislation card by clicking the contextual link button and selecting **Translate**, like so: ![Digipalvelulaki: Viranomaisten digitaalisten palvelujen järjestäminen yleisölle | Suomidigi 2019-08-21 11-28-25](https://user-images.githubusercontent.com/1712902/63415844-03dad900-c407-11e9-9344-d9a6c9067ce6.jpg)
   - Add new translation by clicking add (or Lisää)
   - Fill in the necessary fields and check that all Attachment files are cleared of default values ![Create English translation of Kortti 1: Tietoturvallisuus, tietosuoja, löydettävyys ja helppokäyttöisyys | Suomidigi 2019-08-21 11-40-13](https://user-images.githubusercontent.com/1712902/63416654-7b5d3800-c408-11e9-8a41-b114848250cd.jpg)
   - Add the attachment files and save the node
   - See that the node is fully translated and that the freshly added attachments are found. 
   - Go to Finnish version of the node and check that the original fields still exists.
- Head to http://suomidigi.fi.docker.amazee.io/en/node/125 and check that the card shown is the translated card, note. If there are no cards on the page, edit the page and make sure the Legislation cards paragraph has the correct taxonomy term reference.
