### PR TITLE
SUOPA-X Legislation card liftup breadcrumb

### DIFF
--- a/conf/cmi/core.entity_form_display.taxonomy_term.legislation.default.yml
+++ b/conf/cmi/core.entity_form_display.taxonomy_term.legislation.default.yml
@@ -1,0 +1,71 @@
+uuid: e20e2158-cc3b-4d99-9e01-2a0f40f77761
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.legislation.field_legislation_liftup_title
+    - taxonomy.vocabulary.legislation
+  module:
+    - hide_revision_field
+    - path
+    - text
+id: taxonomy_term.legislation.default
+targetEntityType: taxonomy_term
+bundle: legislation
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  field_legislation_liftup_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  langcode:
+    type: language_select
+    weight: 3
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  revision_log_message:
+    type: hide_revision_field_log_widget
+    weight: 6
+    region: content
+    settings:
+      show: true
+      default: ''
+      permission_based: false
+      allow_user_settings: true
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_view_display.taxonomy_term.legislation.default.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.legislation.default.yml
@@ -1,0 +1,16 @@
+uuid: 649065d2-3353-4afa-a737-38cad71a2294
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.legislation.field_legislation_liftup_title
+    - taxonomy.vocabulary.legislation
+id: taxonomy_term.legislation.default
+targetEntityType: taxonomy_term
+bundle: legislation
+mode: default
+content: {  }
+hidden:
+  description: true
+  field_legislation_liftup_title: true
+  langcode: true

--- a/conf/cmi/field.field.taxonomy_term.legislation.field_legislation_liftup_title.yml
+++ b/conf/cmi/field.field.taxonomy_term.legislation.field_legislation_liftup_title.yml
@@ -1,0 +1,19 @@
+uuid: c7fe18c1-d1ec-4ef2-8785-f324f04a0dd7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_legislation_liftup_title
+    - taxonomy.vocabulary.legislation
+id: taxonomy_term.legislation.field_legislation_liftup_title
+field_name: field_legislation_liftup_title
+entity_type: taxonomy_term
+bundle: legislation
+label: 'Liftup title'
+description: 'Type in a shortened version of the term name. This field will replace term name in legislation card liftup.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.taxonomy_term.field_legislation_liftup_title.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_legislation_liftup_title.yml
@@ -1,0 +1,21 @@
+uuid: 2130cabc-59eb-4b03-a59e-f364edbfdea9
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_legislation_liftup_title
+field_name: field_legislation_liftup_title
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.taxonomy_term.legislation.field_legislation_liftup_title.yml
+++ b/conf/cmi/language/fi/field.field.taxonomy_term.legislation.field_legislation_liftup_title.yml
@@ -1,0 +1,2 @@
+label: Nosto-otsikko
+description: 'Kirjoita kenttään lyhennetty versio taksonomia termin nimestä. Kentän sisältö näytetään lakikortin noston yhteydessä.'

--- a/public/modules/custom/suopa_legislations/suopa_legislations.module
+++ b/public/modules/custom/suopa_legislations/suopa_legislations.module
@@ -86,6 +86,7 @@ function suopa_legislations_preprocess_node(&$variables) {
     // Get label for legislation card and render it as a breadcrumb.
     // Label is built from legislation section term parents.
     if ($node->hasField('field_legislation_section')) {
+      $current_language = Drupal::languageManager()->getCurrentLanguage()->getId();
       $section = $node->get('field_legislation_section')->target_id;
 
       if (!empty($section)) {
@@ -97,7 +98,20 @@ function suopa_legislations_preprocess_node(&$variables) {
 
         $list = [];
         foreach ($ancestors as $term) {
-          $list[$term->id()] = $term->label();
+          if ($term->hasTranslation($current_language)) {
+            $term = $term->getTranslation($current_language);
+          }
+
+          $label = $term->label();
+
+          // Use legislation term liftup title if it exists.
+          if (
+            $term->hasField('field_legislation_liftup_title') &&
+            !empty($term->field_legislation_liftup_title->value)
+          ) {
+            $label = $term->field_legislation_liftup_title->value;
+          }
+          $list[$term->id()] = $label;
         }
 
         if (!empty($list)) {


### PR DESCRIPTION
Depends on https://github.com/vrk-kpa/suomidigi/pull/72

To test: 
- `make fresh`
- Go to http://suomidigi.fi.docker.amazee.io/admin/structure/taxonomy/manage/legislation/overview and edit these terms: 
![Legislation | Suomidigi 2019-08-28 12-01-01](https://user-images.githubusercontent.com/1712902/63841504-98a38080-c98b-11e9-95fe-2e8de5e8a1ed.jpg)
   - Add Liftup titles and translate at least one of the titles
- Save the terms and head to http://suomidigi.fi.docker.amazee.io/test 
- Check that the legislation card liftup breadcrumb uses liftup titles (if they are set..)
- Also check http://suomidigi.fi.docker.amazee.io/en/test for the translations
