### PR TITLE
SUOPA-515 Language links

### DIFF
--- a/conf/cmi/block.block.languageswitcher.yml
+++ b/conf/cmi/block.block.languageswitcher.yml
@@ -1,0 +1,20 @@
+uuid: 9ebd9a1e-4a31-4ac6-9bfc-2ab473029949
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+  theme:
+    - suomidigi
+id: languageswitcher
+theme: suomidigi
+region: header
+weight: 0
+provider: null
+plugin: 'language_block:language_interface'
+settings:
+  id: 'language_block:language_interface'
+  label: 'Language switcher'
+  provider: language
+  label_display: '0'
+visibility: {  }

--- a/conf/cmi/core.base_field_override.community.community.status.yml
+++ b/conf/cmi/core.base_field_override.community.community.status.yml
@@ -1,0 +1,22 @@
+uuid: c8a5422b-99d3-4df5-a7b2-886e05a88bca
+langcode: en
+status: true
+dependencies:
+  module:
+    - suopa_communities
+id: community.community.status
+field_name: status
+entity_type: community
+bundle: community
+label: Published
+description: 'A boolean indicating whether the Community is published.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/core.base_field_override.community.community.user_id.yml
+++ b/conf/cmi/core.base_field_override.community.community.user_id.yml
@@ -1,0 +1,20 @@
+uuid: edc94cb1-a0c4-4796-9f0f-2e04abbdb328
+langcode: en
+status: true
+dependencies:
+  module:
+    - suopa_communities
+id: community.community.user_id
+field_name: user_id
+entity_type: community
+bundle: community
+label: 'Authored by'
+description: 'The user ID of author of the Community entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/conf/cmi/core.entity_form_display.paragraph.liftup_prominent.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.liftup_prominent.default.yml
@@ -3,13 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.entity_reference_browser
     - field.field.paragraph.liftup_prominent.field_p_entity_reference
     - field.field.paragraph.liftup_prominent.field_p_link
     - field.field.paragraph.liftup_prominent.field_p_link_target
     - paragraphs.paragraphs_type.liftup_prominent
   module:
+    - entity_browser
     - link
-    - select2
 id: paragraph.liftup_prominent.default
 targetEntityType: paragraph
 bundle: liftup_prominent
@@ -18,11 +19,16 @@ content:
   field_p_entity_reference:
     weight: 0
     settings:
-      width: 400px
-      autocomplete: true
-      match_operator: STARTS_WITH
+      entity_browser: entity_reference_browser
+      field_widget_display: label
+      field_widget_edit: true
+      field_widget_remove: true
+      selection_mode: selection_append
+      field_widget_replace: false
+      open: false
+      field_widget_display_settings: {  }
     third_party_settings: {  }
-    type: select2_entity_reference
+    type: entity_browser_entity_reference
     region: content
   field_p_link:
     weight: 1
@@ -39,6 +45,11 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   status: true

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -73,6 +73,7 @@ module:
   simplei: 0
   smart_trim: 0
   suopa_communities: 0
+  suopa_content: 0
   suopa_dream_broker: 0
   suopa_editorial: 0
   suopa_external_files: 0

--- a/conf/cmi/language.content_settings.community.community.yml
+++ b/conf/cmi/language.content_settings.community.community.yml
@@ -1,0 +1,17 @@
+uuid: 5089ec21-c7e8-4b62-9739-a7326e3ae821
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_translation
+    - suopa_communities
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: community.community
+target_entity_type_id: community
+target_bundle: community
+default_langcode: fi
+language_alterable: false

--- a/conf/cmi/language.content_settings.taxonomy_term.community_domain.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.community_domain.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.community_domain
 target_entity_type_id: taxonomy_term
 target_bundle: community_domain

--- a/conf/cmi/language.content_settings.user.user.yml
+++ b/conf/cmi/language.content_settings.user.user.yml
@@ -13,5 +13,5 @@ third_party_settings:
 id: user.user
 target_entity_type_id: user
 target_bundle: user
-default_langcode: site_default
+default_langcode: fi
 language_alterable: false

--- a/conf/cmi/language.entity.en.yml
+++ b/conf/cmi/language.entity.en.yml
@@ -7,5 +7,5 @@ _core:
 id: en
 label: English
 direction: ltr
-weight: 0
+weight: -8
 locked: false

--- a/conf/cmi/language.entity.fi.yml
+++ b/conf/cmi/language.entity.fi.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: fi
 label: Finnish
 direction: ltr
-weight: 1
+weight: -10
 locked: false

--- a/conf/cmi/language.entity.sv.yml
+++ b/conf/cmi/language.entity.sv.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: sv
 label: Swedish
 direction: ltr
-weight: 2
+weight: -9
 locked: false

--- a/conf/cmi/language/fi/webform.webform_options.translations.yml
+++ b/conf/cmi/language/fi/webform.webform_options.translations.yml
@@ -1,1 +1,2 @@
+label: Käännökset
 category: Kieli

--- a/conf/cmi/language/sv/tour.tour.search-api-index.yml
+++ b/conf/cmi/language/sv/tour.tour.search-api-index.yml
@@ -1,3 +1,5 @@
 tips:
+  search-api-index-status:
+    label: Status
   search-api-index-tracker:
     label: Spårare

--- a/conf/cmi/language/sv/views.view.content.yml
+++ b/conf/cmi/language/sv/views.view.content.yml
@@ -25,6 +25,7 @@ display:
         name:
           label: Författare
         status:
+          label: Status
           settings:
             format_custom_true: Publicerad
             format_custom_false: 'Ej publicerad'
@@ -40,6 +41,8 @@ display:
           expose:
             label: Innehållstyp
         status:
+          expose:
+            label: Status
           group_info:
             label: 'Status för publicering'
             group_items:

--- a/conf/cmi/language/sv/views.view.files.yml
+++ b/conf/cmi/language/sv/views.view.files.yml
@@ -28,6 +28,7 @@ display:
         filesize:
           label: Storlek
         status:
+          label: Status
           settings:
             format_custom_false: Temporär
         created:
@@ -43,6 +44,9 @@ display:
         filemime:
           expose:
             label: 'Typ av MIME'
+        status:
+          expose:
+            label: Status
       title: Filer
       empty:
         area_text_custom:

--- a/conf/cmi/language/sv/views.view.media.yml
+++ b/conf/cmi/language/sv/views.view.media.yml
@@ -1,4 +1,3 @@
-label: Media
 display:
   default:
     display_title: Huvud
@@ -31,6 +30,7 @@ display:
         uid:
           label: Författare
         status:
+          label: Status
           settings:
             format_custom_true: Publicerad
             format_custom_false: 'Ej publicerad'
@@ -55,6 +55,3 @@ display:
         langcode:
           expose:
             label: Språk
-      title: Media
-  media_page_list:
-    display_title: Media

--- a/conf/cmi/language/sv/views.view.media_library.yml
+++ b/conf/cmi/language/sv/views.view.media_library.yml
@@ -35,12 +35,8 @@ display:
         created:
           expose:
             label: 'Nyaste först'
-      title: Media
   page:
     display_title: Sida
-    display_options:
-      menu:
-        title: Media
   widget:
     display_options:
       filters:

--- a/conf/cmi/language/sv/views.view.scheduler_scheduled_content.yml
+++ b/conf/cmi/language/sv/views.view.scheduler_scheduled_content.yml
@@ -21,6 +21,7 @@ display:
         name:
           label: Författare
         status:
+          label: Status
           settings:
             format_custom_true: Publicerad
             format_custom_false: 'Ej publicerad'
@@ -34,6 +35,8 @@ display:
           expose:
             label: Innehållstyp
         status:
+          expose:
+            label: Status
           group_info:
             label: 'Status för publicering'
             group_items:

--- a/conf/cmi/language/sv/views.view.user_admin_people.yml
+++ b/conf/cmi/language/sv/views.view.user_admin_people.yml
@@ -28,6 +28,7 @@ display:
         name:
           label: Användarnamn
         status:
+          label: Status
           settings:
             format_custom_true: Aktiv
             format_custom_false: Spärrad
@@ -45,6 +46,7 @@ display:
             label: 'Namn eller e-post innehåller'
         status:
           group_info:
+            label: Status
             group_items:
               1:
                 title: Aktiv

--- a/public/modules/custom/suopa_content/suopa_content.info.yml
+++ b/public/modules/custom/suopa_content/suopa_content.info.yml
@@ -1,0 +1,5 @@
+name: 'SuoPa Content'
+type: module
+description: 'Performs alterations for Suomidigi content.'
+core: 8.x
+package: 'SuoPa'

--- a/public/modules/custom/suopa_content/suopa_content.module
+++ b/public/modules/custom/suopa_content/suopa_content.module
@@ -30,8 +30,7 @@ function suopa_content_help($route_name, RouteMatchInterface $route_match) {
  * Switch link title as desired.
  */
 function suopa_content_language_switch_links_alter(array &$links, $type, $path) {
-  $params = \Drupal::routeMatch()->getParameters()->all();
-  $entity = reset($params);
+  $entity = suopa_content_get_route_entity();
 
   foreach ($links as $lang_code => &$link) {
     switch ($lang_code) {
@@ -50,10 +49,35 @@ function suopa_content_language_switch_links_alter(array &$links, $type, $path) 
 
     $link['#abbreviation'] = $lang_code;
     if (
+      $entity &&
       $entity instanceof ContentEntityInterface &&
       !$entity->hasTranslation($lang_code)
     ) {
       $link['#untranslated'] = TRUE;
+    }
+  }
+}
+
+/**
+ * Helper function to extract the entity for the supplied route.
+ *
+ * @return null|ContentEntityInterface
+ */
+function suopa_content_get_route_entity() {
+  $route_match = \Drupal::routeMatch();
+  // Entity will be found in the route parameters.
+  if (($route = $route_match->getRouteObject()) && ($parameters = $route->getOption('parameters'))) {
+    // Determine if the current route represents an entity.
+    foreach ($parameters as $name => $options) {
+      if (isset($options['type']) && strpos($options['type'], 'entity:') === 0) {
+        $entity = $route_match->getParameter($name);
+        if ($entity instanceof ContentEntityInterface && $entity->hasLinkTemplate('canonical')) {
+          return $entity;
+        }
+
+        // Since entity was found, no need to iterate further.
+        return NULL;
+      }
     }
   }
 }

--- a/public/modules/custom/suopa_content/suopa_content.module
+++ b/public/modules/custom/suopa_content/suopa_content.module
@@ -62,6 +62,7 @@ function suopa_content_language_switch_links_alter(array &$links, $type, $path) 
  * Helper function to extract the entity for the supplied route.
  *
  * @return null|ContentEntityInterface
+ *   Returns the found entity or null.
  */
 function suopa_content_get_route_entity() {
   $route_match = \Drupal::routeMatch();

--- a/public/modules/custom/suopa_content/suopa_content.module
+++ b/public/modules/custom/suopa_content/suopa_content.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
+
 /**
  * Implements hook_help().
  */
@@ -38,9 +39,11 @@ function suopa_content_language_switch_links_alter(array &$links, $type, $path) 
         case 'en':
           $link['title'] = 'In English';
           break;
+
         case 'sv':
           $link['title'] = 'På svenska';
           break;
+
         case 'fi':
           $link['title'] = 'Suomeksi';
           break;

--- a/public/modules/custom/suopa_content/suopa_content.module
+++ b/public/modules/custom/suopa_content/suopa_content.module
@@ -33,27 +33,27 @@ function suopa_content_language_switch_links_alter(array &$links, $type, $path) 
   $params = \Drupal::routeMatch()->getParameters()->all();
   $entity = reset($params);
 
-  if ($entity instanceof ContentEntityInterface) {
-    foreach ($links as $lang_code => &$link) {
-      switch ($lang_code) {
-        case 'en':
-          $link['title'] = 'In English';
-          break;
+  foreach ($links as $lang_code => &$link) {
+    switch ($lang_code) {
+      case 'en':
+        $link['title'] = 'In English';
+        break;
 
-        case 'sv':
-          $link['title'] = 'På svenska';
-          break;
+      case 'sv':
+        $link['title'] = 'På svenska';
+        break;
 
-        case 'fi':
-          $link['title'] = 'Suomeksi';
-          break;
-      }
+      case 'fi':
+        $link['title'] = 'Suomeksi';
+        break;
+    }
 
-      $link['#abbreviation'] = $lang_code;
-
-      if (!$entity->hasTranslation($lang_code)) {
-        $link['#untranslated'] = TRUE;
-      }
+    $link['#abbreviation'] = $lang_code;
+    if (
+      $entity instanceof ContentEntityInterface &&
+      !$entity->hasTranslation($lang_code)
+    ) {
+      $link['#untranslated'] = TRUE;
     }
   }
 }

--- a/public/modules/custom/suopa_content/suopa_content.module
+++ b/public/modules/custom/suopa_content/suopa_content.module
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Contains suopa_content.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+/**
+ * Implements hook_help().
+ */
+function suopa_content_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the suopa_content module.
+    case 'help.page.suopa_content':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Performs alterations for Suomidigi content.') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_language_switch_links_alter().
+ *
+ * Switch link title as desired.
+ */
+function suopa_content_language_switch_links_alter(array &$links, $type, $path) {
+  $params = \Drupal::routeMatch()->getParameters()->all();
+  $entity = reset($params);
+
+  if ($entity instanceof ContentEntityInterface) {
+    foreach ($links as $lang_code => &$link) {
+      switch ($lang_code) {
+        case 'en':
+          $link['title'] = 'In English';
+          break;
+        case 'sv':
+          $link['title'] = 'På svenska';
+          break;
+        case 'fi':
+          $link['title'] = 'Suomeksi';
+          break;
+      }
+
+      $link['#abbreviation'] = $lang_code;
+
+      if (!$entity->hasTranslation($lang_code)) {
+        $link['#untranslated'] = TRUE;
+      }
+    }
+  }
+}

--- a/public/themes/custom/suomidigi/src/js/languageSwitcher.js
+++ b/public/themes/custom/suomidigi/src/js/languageSwitcher.js
@@ -1,0 +1,50 @@
+(function ($, Drupal) {
+  Drupal.behaviors.languageSwitcher = {
+    attach: function(context) {
+      let languageSwitchToggleButton = $('.language-switch__button', context);
+      let languageSwitchWrapper = $('.language-switch__wrapper', context);
+
+      const outsideClickListener = (event) => {
+        let target = $(event.target);
+        if (!target.closest('.language-switch__wrapper').length && $('.language-switch__wrapper').is(':visible')) {
+          handleInteraction(event);
+          removeClickListener();
+        }
+      };
+
+      const removeClickListener = () => {
+        document.removeEventListener('click', outsideClickListener);
+      };
+
+      function handleInteraction(e) {
+        e.preventDefault();
+
+        if (languageSwitchWrapper.hasClass('is-active')) {
+          languageSwitchWrapper.removeClass('is-active').attr('aria-hidden', 'true');
+          languageSwitchToggleButton.attr('aria-expanded', 'false');
+        }
+        else {
+          languageSwitchWrapper.addClass('is-active').attr('aria-hidden', 'false');
+          languageSwitchToggleButton.attr('aria-expanded', 'true');
+          document.addEventListener('click', outsideClickListener);
+        }
+      }
+
+      languageSwitchToggleButton.on({
+        touchstart: function(e) {
+          handleInteraction(e);
+        },
+        click: function(e) {
+          handleInteraction(e);
+        },
+        keydown: function (e) {
+          if (e.which === 27) {
+            languageSwitchWrapper.removeClass('is-active').attr('aria-hidden', 'true');
+            languageSwitchToggleButton.attr('aria-expanded', 'false');
+            removeClickListener();
+          }
+        }
+      });
+    }
+  }
+})(jQuery, Drupal);

--- a/public/themes/custom/suomidigi/src/js/menu.mobile.js
+++ b/public/themes/custom/suomidigi/src/js/menu.mobile.js
@@ -30,7 +30,7 @@
             `  <span class="logo--text">${siteName}</span></a>` +
             `  <p class="site-slogan">${siteSlogan}</p>` +
             `</header>` +
-            `<div class="moby-menu"></div>` +
+            `<div id="moby-menu" class="moby-menu"></div>` +
             `<div id="moby-shortcuts" class="moby-shortcuts"></div>`;
 
           mobyMenu = new Moby({
@@ -53,6 +53,7 @@
             template: template
           });
 
+          $('#block-languageswitcher').contents().clone().appendTo('#moby-menu');
           $('#block-suopa-shortcuts-block-mobile').contents().appendTo('#moby-shortcuts');
           $('#moby-shortcuts div.taxonomy-term.vocabulary-theme').each(function() {
             var id = $(this).attr('id');

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-language.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-language.scss
@@ -1,0 +1,162 @@
+.language-switch {
+  display: none;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    display: block;
+    margin: 0 0 0 auto;
+    padding: 0;
+
+    &__wrapper {
+      line-height: 0;
+      position: relative;
+
+      &:not(.is-active) .language-switch__dropdown {
+        display: none;
+      }
+    }
+
+    &__button {
+      @include font-size(14px);
+      @include line-height(14px, 14px);
+      align-items: center;
+      background: $blue-dark;
+      border: 1px solid $gray-light;
+      border-radius: 2px;
+      color: $white;
+      display: flex;
+      justify-content: center;
+      padding: 0;
+      text-transform: uppercase;
+      text-align: center;
+      width: 44px;
+      height: 30px;
+
+      &[aria-expanded=true] {
+        color: $orange-dark;
+
+        svg {
+          fill: $orange-dark;
+          transform: rotate(180deg);
+        }
+      }
+
+      .icon {
+        display: inline-block;
+        fill: $white;
+        margin-right: -3px;
+        max-height: 15px;
+        width: 18px;
+
+        &__wrapper {
+          line-height: 0;
+          margin-left: 2px;
+        }
+      }
+    }
+
+    &__dropdown {
+      background: $white;
+      border: 1px solid $gray-light;
+      box-shadow: 0 2px 3px 0 rgba(0, 0, 0, .2);
+      border-radius: 2px;
+      position: absolute;
+      right: 0;
+      top: 45px;
+      z-index: 1000;
+
+      &:after,
+      &:before {
+        bottom: 100%;
+        right: 20px;
+        border: solid transparent;
+        content: " ";
+        height: 0;
+        width: 0;
+        position: absolute;
+        pointer-events: none;
+      }
+
+      &:before {
+        border-bottom-color: $gray-light;
+        border-width: 8px;
+        margin-right: -8px;
+      }
+
+      &:after {
+        border-bottom-color: $white;
+        border-width: 7px;
+        margin-right: -7px;
+      }
+
+      .language-links {
+        padding-top: 10px;
+        padding-bottom: 10px;
+
+        .language-link {
+          @include font-size(16px);
+          @include line-height(16px, 26px);
+          padding-left: 14px;
+          border-left: 6px solid transparent;
+          padding-right: 20px;
+          white-space: nowrap;
+          text-decoration: none;
+          display: block;
+          color: $blue-dark;
+
+          &.is-active,
+          &:focus,
+          &:hover {
+            border-left: 6px solid $blue-light;
+          }
+
+          &.is-active {
+            font-weight: bold;
+          }
+        }
+
+        span.language-link:not(.is-active) {
+          color: $gray-medium;
+
+          &:focus,
+          &:hover {
+            border-left: 6px solid transparent;
+          }
+        }
+      }
+    }
+  }
+}
+
+.moby-menu {
+  .language-switch {
+    &__button {
+      display: none;
+    }
+
+    &__wrapper {
+      padding-top: $gutter;
+      border-top: 1px solid rgba(165, 172, 176, .3);
+      margin-top: $gutter;
+
+      .language-links {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+      }
+
+      .language-link {
+        text-transform: uppercase;
+        padding: 0 $gutter / 2;
+
+        &--abbreviation {
+          display: none;
+        }
+      }
+//////////////////////
+      span.language-link:not(.is-active) {
+        color: $gray-medium;
+      }
+
+    }
+  }
+}

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-mobile.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-mobile.scss
@@ -47,7 +47,7 @@
 
   .moby-menu {
     border-bottom: 1px solid rgba(165,172,176,.3);
-    padding-bottom: $gutter*2;
+    padding-bottom: $gutter;
 
     .menu {
       list-style: none;

--- a/public/themes/custom/suomidigi/suomidigi.libraries.yml
+++ b/public/themes/custom/suomidigi/suomidigi.libraries.yml
@@ -2,6 +2,10 @@ search-toggle:
   js:
     dist/js/searchToggle.min.js: {}
 
+language-switcher:
+  js:
+    dist/js/languageSwitcher.min.js: {}
+
 article-teaser-content-height:
   js:
     dist/js/articleTeaserContentHeight.min.js: {}
@@ -34,3 +38,4 @@ global-scripting:
     - suomidigi/search-toggle
     - suomidigi/article-teaser-content-height
     - suomidigi/leanlab-questionnaire
+    - suomidigi/language-switcher

--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -16,6 +16,9 @@ use Drupal\views\ViewExecutable;
  */
 function suomidigi_preprocess(&$variables) {
   $variables['icons_path'] = suomidigi_get_icons_path();
+  $variables['current_language'] = Drupal::languageManager()
+    ->getCurrentLanguage()
+    ->getId();
   $variables['#attached']['drupalSettings']['iconsPath'] = $variables['icons_path'];
 }
 
@@ -29,6 +32,20 @@ function suomidigi_preprocess(&$variables) {
  */
 function suomidigi_preprocess_html(&$variables) {
   $variables['theme_path'] = file_create_url(drupal_get_path('theme', 'suomidigi'));
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Set site slogan and site name as variables for javascript templates.
+ */
+function suomidigi_preprocess_page(&$variables) {
+  $site_config = Drupal::config('system.site');
+  $settings = [
+    'siteSlogan' => $site_config->get('slogan'),
+    'siteName' => $site_config->get('name'),
+  ];
+  $variables['#attached']['drupalSettings'] = $settings;
 }
 
 /**
@@ -186,15 +203,6 @@ function suomidigi_preprocess_menu(&$variables) {
         unset($variables['items'][$key]);
       }
     }
-  }
-
-  if (
-    isset($variables['attributes']['block_id']) &&
-    $variables['attributes']['block_id'] == 'menu_mobile'
-  ) {
-    $site_config = Drupal::config('system.site');
-    $variables['#attached']['drupalSettings']['siteSlogan'] = $site_config->get('slogan');
-    $variables['#attached']['drupalSettings']['siteName'] = $site_config->get('name');
   }
 }
 

--- a/public/themes/custom/suomidigi/templates/blocks/block--language-block--language-interface.html.twig
+++ b/public/themes/custom/suomidigi/templates/blocks/block--language-block--language-interface.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ */
+#}
+{%
+  set classes = [
+  'language-switch',
+  'block-' ~ configuration.provider|clean_class,
+  'block-' ~ plugin_id|clean_class,
+]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/public/themes/custom/suomidigi/templates/navigation/links--language-block.html.twig
+++ b/public/themes/custom/suomidigi/templates/navigation/links--language-block.html.twig
@@ -1,0 +1,68 @@
+{#
+/**
+ * @file
+ * Theme override for a set of links.
+ *
+ * Available variables:
+ * - attributes: Attributes for the UL containing the list of links.
+ * - links: Links to be output.
+ *   Each link will have the following elements:
+ *   - title: The link text.
+ *   - href: The link URL. If omitted, the 'title' is shown as a plain text
+ *     item in the links list. If 'href' is supplied, the entire link is passed
+ *     to l() as its $options parameter.
+ *   - attributes: (optional) HTML attributes for the anchor, or for the <span>
+ *     tag if no 'href' is supplied.
+ * - heading: (optional) A heading to precede the links.
+ *   - text: The heading text.
+ *   - level: The heading level (e.g. 'h2', 'h3').
+ *   - attributes: (optional) A keyed list of attributes for the heading.
+ *   If the heading is a string, it will be used as the text of the heading and
+ *   the level will default to 'h2'.
+ *
+ *   Headings should be used on navigation menus and any list of links that
+ *   consistently appears on multiple pages. To make the heading invisible use
+ *   the 'visually-hidden' CSS class. Do not use 'display:none', which
+ *   removes it from screen readers and assistive technology. Headings allow
+ *   screen reader and keyboard only users to navigate to or skip the links.
+ *   See http://juicystudio.com/article/screen-readers-display-none.php and
+ *   http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ *
+ * @see template_preprocess_links()
+ */
+#}
+
+{% if links -%}
+  <div {{ attributes.addClass('language-switch__wrapper') }}>
+    <button class="language-switch__button" aria-expanded="false" aria-controls="language-switch-dropdown" aria-haspopup="menu" aria-label="{{ 'Select language'|t }}">
+      {% if current_language %}
+        {{ current_language|upper }}
+      {% endif %}
+      <span class="icon__wrapper" aria-hidden="true">
+        {% if icons_path %}
+          <svg class="icon">
+            <title>{{ text }}</title>
+            <use xlink:href="{{ icons_path|trim }}#chevron-down"/>
+          </svg>
+        {% endif %}
+      </span>
+    </button>
+    <div aria-hidden="true" id="language-switch-dropdown" class="language-switch__dropdown">
+      <div class="language-links">
+        {%- for item in links -%}
+          {% set lang = item.link['#options']['#abbreviation'] %}
+          {% set untranslated = item.link['#options']['#untranslated'] %}
+
+          {%- if not untranslated and lang != current_language -%}
+            {% set language_link = path('<current>', {}, {'language': item.link['#options']['language']}) %}
+            <a class="language-link{{ lang == current_language ? ' is-active' : '' }}" lang="{{ lang }}" href="{{ language_link }}">{{ item.text }} <span class="language-link--abbreviation">({{ lang|upper }})</span></a>
+          {%- elseif lang == current_language -%}
+            <span class="language-link is-active">{{ item.text }} <span class="language-link--abbreviation">({{ lang|upper }})</span></span>
+          {%- else -%}
+            <span class="language-link">{{ item.text }} <span class="language-link--abbreviation">({{ lang|upper }})</span></span>
+          {%- endif -%}
+        {%- endfor -%}
+      </div>
+    </div>
+  </div>
+{%- endif %}


### PR DESCRIPTION
To test:
- `make fresh`
- Log in and clear caches
- Test that the language switcher works on mobile and desktop and that it has a resemblance of suomi.fi language switcher (see below)

![Suomidigi - Suomidigi 2019-09-09 18-48-51](https://user-images.githubusercontent.com/1712902/64546246-f7291100-d332-11e9-8583-4a15240809c8.jpg)

![Etusivu - Suomi fi 2019-09-09 18-47-10](https://user-images.githubusercontent.com/1712902/64546269-ff814c00-d332-11e9-9643-7a5a9292201c.jpg)
