### PR TITLE
SUOPA-526 Theme tag lists

### DIFF
--- a/conf/cmi/core.entity_form_display.community.community.default.yml
+++ b/conf/cmi/core.entity_form_display.community.community.default.yml
@@ -7,8 +7,10 @@ dependencies:
     - field.field.community.community.field_community_description
     - field.field.community.community.field_community_domain
     - field.field.community.community.field_community_link
+    - field.field.community.community.field_theme
   module:
     - link
+    - select2
     - suopa_communities
     - text
 id: community.community.default
@@ -38,16 +40,25 @@ content:
     type: options_select
     region: content
   field_community_link:
-    weight: 4
+    weight: 5
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
     region: content
+  field_theme:
+    weight: 4
+    settings:
+      width: 400px
+      match_operator: CONTAINS
+      autocomplete: false
+    third_party_settings: {  }
+    type: select2_entity_reference
+    region: content
   langcode:
     type: language_select
-    weight: 5
+    weight: 6
     region: content
     settings:
       include_locked: true
@@ -62,7 +73,7 @@ content:
     third_party_settings: {  }
   user_id:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60

--- a/conf/cmi/core.entity_form_display.taxonomy_term.theme.default.yml
+++ b/conf/cmi/core.entity_form_display.taxonomy_term.theme.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - entity_browser.browser.media_image_browser
+    - field.field.taxonomy_term.theme.field_before_content_paragraphs
     - field.field.taxonomy_term.theme.field_liftup_image
     - field.field.taxonomy_term.theme.field_paragraphs
     - taxonomy.vocabulary.theme
@@ -17,24 +18,43 @@ targetEntityType: taxonomy_term
 bundle: theme
 mode: default
 content:
+  field_before_content_paragraphs:
+    type: paragraphs
+    weight: 3
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed_expand_nested
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        duplicate: duplicate
+        collapse_edit_all: collapse_edit_all
+        add_above: '0'
+    third_party_settings: {  }
+    region: content
   field_liftup_image:
     type: entity_browser_entity_reference
-    weight: 1
+    weight: 2
     settings:
       entity_browser: media_image_browser
       field_widget_display: rendered_entity
+      field_widget_display_settings:
+        view_mode: media_library
       field_widget_edit: true
       field_widget_remove: true
       field_widget_replace: true
       open: true
       selection_mode: selection_append
-      field_widget_display_settings:
-        view_mode: default
     third_party_settings: {  }
     region: content
   field_paragraphs:
     type: paragraphs
-    weight: 2
+    weight: 4
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -53,7 +73,7 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 3
+    weight: 1
     region: content
     settings:
       include_locked: true
@@ -68,13 +88,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   revision_log_message:
     type: hide_revision_field_log_widget
-    weight: 6
+    weight: 7
     region: content
     settings:
       show: true
@@ -85,7 +105,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.community.community.default.yml
+++ b/conf/cmi/core.entity_view_display.community.community.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.community.community.field_community_description
     - field.field.community.community.field_community_domain
     - field.field.community.community.field_community_link
+    - field.field.community.community.field_theme
   module:
     - link
     - suopa_communities
@@ -54,6 +55,14 @@ content:
     third_party_settings: {  }
     type: link
     region: content
+  field_theme:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   name:
     label: hidden
     type: string
@@ -71,3 +80,4 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.community.community.teaser.yml
+++ b/conf/cmi/core.entity_view_display.community.community.teaser.yml
@@ -4,9 +4,11 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.community.teaser
+    - field.field.community.community.field_approved
     - field.field.community.community.field_community_description
     - field.field.community.community.field_community_domain
     - field.field.community.community.field_community_link
+    - field.field.community.community.field_theme
   module:
     - link
     - suopa_communities
@@ -53,5 +55,8 @@ content:
       link_to_entity: false
     third_party_settings: {  }
 hidden:
+  field_approved: true
+  field_theme: true
   langcode: true
+  search_api_excerpt: true
   user_id: true

--- a/conf/cmi/core.entity_view_display.media.image.article_teaser_header_prominent.yml
+++ b/conf/cmi/core.entity_view_display.media.image.article_teaser_header_prominent.yml
@@ -25,6 +25,7 @@ content:
     region: content
 hidden:
   created: true
+  field_creator: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.taxonomy_term.theme.after_content.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.theme.after_content.yml
@@ -1,18 +1,19 @@
-uuid: 94eb5cf3-9cd4-4a6c-a637-22e1c4e1e2d9
+uuid: efb09cfb-1482-40e9-8928-66e2ad1627e6
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.taxonomy_term.after_content
     - field.field.taxonomy_term.theme.field_before_content_paragraphs
     - field.field.taxonomy_term.theme.field_liftup_image
     - field.field.taxonomy_term.theme.field_paragraphs
     - taxonomy.vocabulary.theme
   module:
     - entity_reference_revisions
-id: taxonomy_term.theme.default
+id: taxonomy_term.theme.after_content
 targetEntityType: taxonomy_term
 bundle: theme
-mode: default
+mode: after_content
 content:
   field_paragraphs:
     type: entity_reference_revisions_entity_view

--- a/conf/cmi/core.entity_view_display.taxonomy_term.theme.before_content.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.theme.before_content.yml
@@ -1,31 +1,32 @@
-uuid: 94eb5cf3-9cd4-4a6c-a637-22e1c4e1e2d9
+uuid: 35ad1c17-cfe8-4ea5-ad58-4a1bfc6b0418
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.taxonomy_term.before_content
     - field.field.taxonomy_term.theme.field_before_content_paragraphs
     - field.field.taxonomy_term.theme.field_liftup_image
     - field.field.taxonomy_term.theme.field_paragraphs
     - taxonomy.vocabulary.theme
   module:
     - entity_reference_revisions
-id: taxonomy_term.theme.default
+id: taxonomy_term.theme.before_content
 targetEntityType: taxonomy_term
 bundle: theme
-mode: default
+mode: before_content
 content:
-  field_paragraphs:
+  field_before_content_paragraphs:
     type: entity_reference_revisions_entity_view
     weight: 0
+    region: content
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    region: content
 hidden:
   description: true
-  field_before_content_paragraphs: true
   field_liftup_image: true
+  field_paragraphs: true
   langcode: true
   search_api_excerpt: true

--- a/conf/cmi/core.entity_view_mode.taxonomy_term.after_content.yml
+++ b/conf/cmi/core.entity_view_mode.taxonomy_term.after_content.yml
@@ -1,0 +1,10 @@
+uuid: cc60a8cd-98d6-4779-af19-5d8c2b333907
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.after_content
+label: 'After content'
+targetEntityType: taxonomy_term
+cache: true

--- a/conf/cmi/core.entity_view_mode.taxonomy_term.before_content.yml
+++ b/conf/cmi/core.entity_view_mode.taxonomy_term.before_content.yml
@@ -1,0 +1,10 @@
+uuid: 5a5e767b-113d-4b7c-8e18-cfa9051a0ae0
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.before_content
+label: 'Before content'
+targetEntityType: taxonomy_term
+cache: true

--- a/conf/cmi/field.field.community.community.field_theme.yml
+++ b/conf/cmi/field.field.community.community.field_theme.yml
@@ -1,0 +1,30 @@
+uuid: 9b5cc463-638b-475d-a4cd-e9e19000e532
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.community.field_theme
+    - taxonomy.vocabulary.theme
+  module:
+    - suopa_communities
+id: community.community.field_theme
+field_name: field_theme
+entity_type: community
+bundle: community
+label: Theme
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      theme: theme
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.paragraph.view.field_p_view.yml
+++ b/conf/cmi/field.field.paragraph.view.field_p_view.yml
@@ -31,6 +31,9 @@ settings:
     embed: 0
   preselect_views:
     communities: communities
+    theme_tag_communities: theme_tag_communities
+    theme_tag_lists: theme_tag_lists
+    approval_queue: 0
     block_content: 0
     comment: 0
     comments_recent: 0
@@ -43,6 +46,7 @@ settings:
     media_entity_browser: 0
     media_entity_browser_media_library: 0
     media_library: 0
+    rate: 0
     redirect: 0
     scheduler_scheduled_content: 0
     search: 0

--- a/conf/cmi/field.field.taxonomy_term.theme.field_before_content_paragraphs.yml
+++ b/conf/cmi/field.field.taxonomy_term.theme.field_before_content_paragraphs.yml
@@ -1,0 +1,23 @@
+uuid: b0ed7a79-07c8-4dee-82cf-ec32104082c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_before_content_paragraphs
+    - taxonomy.vocabulary.theme
+  module:
+    - entity_reference_revisions
+id: taxonomy_term.theme.field_before_content_paragraphs
+field_name: field_before_content_paragraphs
+entity_type: taxonomy_term
+bundle: theme
+label: 'Before content - Paragraphs'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings: {  }
+field_type: entity_reference_revisions

--- a/conf/cmi/field.field.taxonomy_term.theme.field_paragraphs.yml
+++ b/conf/cmi/field.field.taxonomy_term.theme.field_paragraphs.yml
@@ -11,8 +11,8 @@ id: taxonomy_term.theme.field_paragraphs
 field_name: field_paragraphs
 entity_type: taxonomy_term
 bundle: theme
-label: Paragraphs
-description: ''
+label: 'After content - Paragraphs'
+description: 'These paragraphs are shown after the dynamic taxonomy term content.'
 required: false
 translatable: false
 default_value: {  }
@@ -28,5 +28,59 @@ settings:
         enabled: false
       text:
         weight: 4
+        enabled: false
+      attachment:
+        weight: 21
+        enabled: false
+      banner_cta:
+        weight: 22
+        enabled: false
+      container:
+        weight: 23
+        enabled: false
+      container_title:
+        weight: 24
+        enabled: false
+      highlight_bullet_point:
+        weight: 25
+        enabled: false
+      highlight_bullet_point_item:
+        weight: 26
+        enabled: false
+      highlight_cta:
+        weight: 27
+        enabled: false
+      highlight_text_box:
+        weight: 28
+        enabled: false
+      legislation_attachment:
+        weight: 29
+        enabled: false
+      legislation_cards:
+        weight: 30
+        enabled: false
+      legislation_link:
+        weight: 31
+        enabled: false
+      liftup_box:
+        weight: 32
+        enabled: false
+      liftup_box_item:
+        weight: 33
+        enabled: false
+      liftup_entity_reference:
+        weight: 34
+        enabled: false
+      liftup_entity_reference_item:
+        weight: 35
+        enabled: false
+      liftup_prominent:
+        weight: 36
+        enabled: false
+      link:
+        weight: 37
+        enabled: false
+      view:
+        weight: 40
         enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.storage.community.field_theme.yml
+++ b/conf/cmi/field.storage.community.field_theme.yml
@@ -1,0 +1,20 @@
+uuid: 468a46b5-3418-4281-9fd8-4780f2c2f9fd
+langcode: en
+status: true
+dependencies:
+  module:
+    - suopa_communities
+    - taxonomy
+id: community.field_theme
+field_name: field_theme
+entity_type: community
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.taxonomy_term.field_before_content_paragraphs.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_before_content_paragraphs.yml
@@ -1,0 +1,21 @@
+uuid: ca004f36-b60a-4ad3-8719-41d3652df149
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+    - taxonomy
+id: taxonomy_term.field_before_content_paragraphs
+field_name: field_before_content_paragraphs
+entity_type: taxonomy_term
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/core.entity_view_mode.taxonomy_term.after_content.yml
+++ b/conf/cmi/language/fi/core.entity_view_mode.taxonomy_term.after_content.yml
@@ -1,0 +1,1 @@
+label: 'Sisältöalueen jälkeen'

--- a/conf/cmi/language/fi/core.entity_view_mode.taxonomy_term.before_content.yml
+++ b/conf/cmi/language/fi/core.entity_view_mode.taxonomy_term.before_content.yml
@@ -1,0 +1,1 @@
+label: 'Ennen sisältöaluetta'

--- a/conf/cmi/language/fi/field.field.taxonomy_term.theme.field_before_content_paragraphs.yml
+++ b/conf/cmi/language/fi/field.field.taxonomy_term.theme.field_before_content_paragraphs.yml
@@ -1,0 +1,2 @@
+label: 'Paragraafit - Ennen sisältöä'
+description: 'Nämä paragraafit näytetään sisältöalueen alussa.'

--- a/conf/cmi/language/fi/field.field.taxonomy_term.theme.field_paragraphs.yml
+++ b/conf/cmi/language/fi/field.field.taxonomy_term.theme.field_paragraphs.yml
@@ -1,1 +1,2 @@
-label: Paragraafit
+label: 'Paragraafit - Sisällön jälkeen'
+description: 'Nämä paragraafit näytetään sisältöalueen jälkeen.'

--- a/conf/cmi/views.view.taxonomy_term.yml
+++ b/conf/cmi/views.view.taxonomy_term.yml
@@ -342,7 +342,20 @@ display:
         type: 'entity:node'
         options:
           view_mode: teaser
-      header: {  }
+      header:
+        entity_taxonomy_term:
+          id: entity_taxonomy_term
+          table: views
+          field: entity_taxonomy_term
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          target: '{{ raw_arguments.tid }}'
+          view_mode: before_content
+          bypass_access: false
+          plugin_id: entity
       footer:
         entity_taxonomy_term:
           id: entity_taxonomy_term

--- a/conf/cmi/views.view.theme_tag_communities.yml
+++ b/conf/cmi/views.view.theme_tag_communities.yml
@@ -1,0 +1,303 @@
+uuid: 3d6783e5-b51b-42d7-b915-d83812a58405
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.community.teaser
+    - taxonomy.vocabulary.theme
+  module:
+    - suopa_communities
+id: theme_tag_communities
+label: 'Theme tag: Communities'
+module: views
+description: ''
+tag: ''
+base_table: community_field_data
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Käytä
+          reset_button: false
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          expose_sort_order: true
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
+      pager:
+        type: some
+        options:
+          items_per_page: 4
+          offset: 0
+      style:
+        type: default
+      row:
+        type: 'entity:community'
+        options:
+          relationship: none
+          view_mode: teaser
+      fields:
+        name:
+          table: community_field_data
+          field: name
+          id: name
+          entity_type: null
+          entity_field: name
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: community_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: community
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_approved_value:
+          id: field_approved_value
+          table: community__field_approved
+          field: field_approved_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+        langcode:
+          id: langcode
+          table: community_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: community
+          entity_field: langcode
+          plugin_id: language
+      sorts:
+        changed:
+          id: changed
+          table: community_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: community
+          entity_field: changed
+          plugin_id: date
+      title: ''
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        field_theme_target_id:
+          id: field_theme_target_id
+          table: community__field_theme
+          field: field_theme_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: true
+            limit: true
+            vids:
+              theme: theme
+            anyall: +
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              theme: theme
+            operation: view
+            multiple: 0
+            access: false
+          break_phrase: false
+          not: false
+          plugin_id: numeric
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+      tags: {  }
+  theme_tag_communities:
+    display_plugin: block
+    id: theme_tag_communities
+    display_title: Communities
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+      tags: {  }

--- a/conf/cmi/views.view.theme_tag_lists.yml
+++ b/conf/cmi/views.view.theme_tag_lists.yml
@@ -1,0 +1,658 @@
+uuid: 5daf44a8-55c0-4de1-b8b5-5de266e4c868
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.article
+    - node.type.core_content
+    - taxonomy.vocabulary.article_type
+    - taxonomy.vocabulary.core_content_type
+    - taxonomy.vocabulary.theme
+  content:
+    - 'taxonomy_term:article_type:23488bb5-eea2-4865-b83f-573c2d5f2872'
+    - 'taxonomy_term:article_type:4d993fe6-3591-4195-8e78-435603afa24f'
+    - 'taxonomy_term:core_content_type:f2acb67b-7ee8-4e66-b581-45044f9c07e7'
+  module:
+    - node
+    - taxonomy
+    - user
+id: theme_tag_lists
+label: 'Theme tag: Articles and Core content'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Käytä
+          reset_button: false
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          expose_sort_order: true
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
+      pager:
+        type: some
+        options:
+          items_per_page: 4
+          offset: 0
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            article: article
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        field_article_type_target_id:
+          id: field_article_type_target_id
+          table: node__field_article_type
+          field: field_article_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            2: 2
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: article_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      sorts:
+        promote:
+          id: promote
+          table: node_field_data
+          field: promote
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: promote
+          plugin_id: standard
+        sticky_1:
+          id: sticky_1
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: standard
+        published_at:
+          id: published_at
+          table: node_field_data
+          field: published_at
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: node
+          entity_field: published_at
+          plugin_id: date
+        sticky:
+          id: sticky
+          table: taxonomy_index
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: standard
+      title: Blogs
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: true
+            limit: true
+            vids:
+              theme: theme
+            anyall: +
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            access: true
+            operation: view
+            multiple: 0
+            bundles: {  }
+          break_phrase: false
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+          plugin_id: taxonomy_index_tid
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  theme_tag_articles:
+    display_plugin: block
+    id: theme_tag_articles
+    display_title: Articles
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: ''
+      defaults:
+        title: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  theme_tag_blogs:
+    display_plugin: block
+    id: theme_tag_blogs
+    display_title: Blogs
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: ''
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            article: article
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        field_article_type_target_id:
+          id: field_article_type_target_id
+          table: node__field_article_type
+          field: field_article_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            13: 13
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: article_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  theme_tag_tools:
+    display_plugin: block
+    id: theme_tag_tools
+    display_title: Tools
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: ''
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            core_content: core_content
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+        field_core_content_type_target_id:
+          id: field_core_content_type_target_id
+          table: node__field_core_content_type
+          field: field_core_content_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            35: 35
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: core_content_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_community.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_community.scss
@@ -23,13 +23,13 @@
   &__icon {
     align-content: center;
     display: flex;
-    margin-right: $gutter;
     justify-content: center;
+    margin-right: $gutter;
 
     img {
-      min-width: $gutter * 2;
-      min-height: $gutter * 2;
       max-width: $gutter * 2;
+      min-height: $gutter * 2;
+      min-width: $gutter * 2;
     }
 
     &--letter {
@@ -42,8 +42,8 @@
       font-weight: bold;
       height: $gutter * 2;
       justify-content: center;
-      text-transform: uppercase;
       text-decoration: none;
+      text-transform: uppercase;
       width: $gutter * 2;
 
       .community__link:hover & {
@@ -95,4 +95,8 @@
     color: $black;
   }
 
+  .theme-term__list-item & {
+    @include border();
+    padding: $gutter;
+  }
 }

--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -295,7 +295,11 @@ function suomidigi_preprocess_taxonomy_term(&$variables) {
 function suomidigi_preprocess_views_view(&$variables) {
   $view = $variables['view'];
 
-  if ($view->id() == 'taxonomy_term' && $view->current_display == 'page_1') {
+  if (
+    ($view->id() == 'taxonomy_term' && $view->current_display == 'page_1') ||
+    $view->id() == 'theme_tag_communities' ||
+    $view->id() == 'theme_tag_lists'
+  ) {
     $variables['attributes']['class'][] = 'theme-term__list';
     $row_style_plugin = &$variables['rows'][0]['#view']->style_plugin;
     $row_style_plugin->options['row_class'] = 'theme-term__list-item';


### PR DESCRIPTION
To test: 
- `make fresh`
- Go to any Theme tag (Teema) and edit the taxonomy term
- Add **View** paragraphs to **Before content** paragraph field. See image below.
![image](https://user-images.githubusercontent.com/1712902/65606463-a1e83300-dfb3-11e9-845d-940371778cb2.png)
- Save the taxonomy term and view it.

**Note:** If the list is rather empty, there's just content missing. Create new content for each of the types and check if the list gets updated. 