### PR TITLE
SUOPA-X Hotfix to convert double double quotes to empty string

### DIFF
--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -523,6 +523,19 @@ function suomidigi_theme_suggestions_input_alter(&$suggestions, array $variables
 /**
  * Implements hook_preprocess_HOOK().
  */
+function suomidigi_preprocess_image(&$variables) {
+  // Convert double double quotes to empty string for image alt-texts.
+  if (
+    isset($variables['alt']) &&
+    $variables['alt'] === '""'
+  ) {
+    $variables['attributes']['alt'] = ' ';
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function suomidigi_preprocess_pager(&$variables) {
   // Cast current to be INT instead of FLOAT.
   $variables['current'] = isset($variables['current']) ? (int) $variables['current'] : 1;


### PR DESCRIPTION
To test: 
- `make fresh`
- Go to f.e. https://suomidigi.docker.sh/blogit/enemman-arvostusta-digitalisaation-hiljaisille-kannattelijoille and edit the page. Edit the image and replace the alt-text to double quotes `""`
- Save the node and check the page source that the alt-text has changed to `alt=" "`