### PR TITLE
SUOPA-X Asynchronous paragraphs migration  [to beta]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,6 +141,9 @@
             },
             "drupal/ckwordcount": {
                 "https://www.drupal.org/project/ckwordcount/issues/2850845": "https://www.drupal.org/files/issues/2019-06-23/ckwordcount_plugin_path_2850845-10.patch"
+            },
+            "drupal/paragraphs": {
+                "https://www.drupal.org/project/paragraphs/issues/2904705": "https://www.drupal.org/files/issues/2019-11-13/experimental-widget-asymetric-translation-2904705-70.patch"
             }
         },
         "hooks": {

--- a/conf/cmi/core.base_field_override.user.user.changed.yml
+++ b/conf/cmi/core.base_field_override.user.user.changed.yml
@@ -11,7 +11,7 @@ bundle: user
 label: Changed
 description: 'The time that the user was last edited.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/core.base_field_override.user.user.changed.yml
+++ b/conf/cmi/core.base_field_override.user.user.changed.yml
@@ -11,7 +11,7 @@ bundle: user
 label: Changed
 description: 'The time that the user was last edited.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/core.entity_form_display.user.user.default.yml
+++ b/conf/cmi/core.entity_form_display.user.user.default.yml
@@ -132,6 +132,11 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   user_picture:
     type: image_focal_point
     settings:

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -69,6 +69,7 @@ module:
   optional_end_date: 0
   options: 0
   page_cache: 0
+  paragraph_translation_migration: 0
   path: 0
   preview_link: 0
   quickedit: 0

--- a/conf/cmi/field.field.node.article.field_paragraphs.yml
+++ b/conf/cmi/field.field.node.article.field_paragraphs.yml
@@ -20,7 +20,7 @@ bundle: article
 label: Paragraphs
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -83,10 +83,19 @@ settings:
       legislation_cards:
         enabled: true
         weight: 17
+      banner_cta:
+        weight: 23
+        enabled: false
       legislation_attachment:
         enabled: true
         weight: 26
+      feed:
+        weight: 26
+        enabled: false
       legislation_link:
         enabled: true
         weight: 28
+      view:
+        weight: 42
+        enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.core_content.field_paragraphs.yml
+++ b/conf/cmi/field.field.node.core_content.field_paragraphs.yml
@@ -20,7 +20,7 @@ bundle: core_content
 label: Paragraphs
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -83,10 +83,19 @@ settings:
       legislation_cards:
         enabled: true
         weight: 17
+      banner_cta:
+        weight: 23
+        enabled: false
       legislation_attachment:
         enabled: true
         weight: 26
+      feed:
+        weight: 26
+        enabled: false
       legislation_link:
         enabled: true
         weight: 28
+      view:
+        weight: 42
+        enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.event.field_event_image.yml
+++ b/conf/cmi/field.field.node.event.field_event_image.yml
@@ -6,7 +6,14 @@ dependencies:
     - field.storage.node.field_event_image
     - node.type.event
   module:
+    - content_translation
     - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
 id: node.event.field_event_image
 field_name: field_event_image
 entity_type: node

--- a/conf/cmi/field.field.node.landing_page.field_paragraphs.yml
+++ b/conf/cmi/field.field.node.landing_page.field_paragraphs.yml
@@ -20,7 +20,7 @@ bundle: landing_page
 label: Paragraphs
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -83,10 +83,19 @@ settings:
       legislation_cards:
         enabled: true
         weight: 17
+      banner_cta:
+        weight: 23
+        enabled: false
       legislation_attachment:
         enabled: true
         weight: 26
+      feed:
+        weight: 26
+        enabled: false
       legislation_link:
         enabled: true
         weight: 28
+      view:
+        weight: 42
+        enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.node.legislation_card.field_attachments.yml
+++ b/conf/cmi/field.field.node.legislation_card.field_attachments.yml
@@ -15,7 +15,7 @@ bundle: legislation_card
 label: Attachments
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.node.legislation_card.field_legislation_materials.yml
+++ b/conf/cmi/field.field.node.legislation_card.field_legislation_materials.yml
@@ -16,7 +16,7 @@ bundle: legislation_card
 label: 'More about the subject'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.node.legislation_collection_page.field_legis_cpage_paragraphs.yml
+++ b/conf/cmi/field.field.node.legislation_collection_page.field_legis_cpage_paragraphs.yml
@@ -19,7 +19,7 @@ bundle: legislation_collection_page
 label: Paragraphs
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -92,5 +92,8 @@ settings:
         enabled: false
       view:
         weight: -22
+        enabled: false
+      feed:
+        weight: 26
         enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.paragraph.container.field_p_content.yml
+++ b/conf/cmi/field.field.paragraph.container.field_p_content.yml
@@ -16,7 +16,7 @@ bundle: container
 label: Content
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -50,5 +50,44 @@ settings:
         enabled: false
       highlight_text_box:
         weight: 14
+        enabled: false
+      attachment:
+        weight: 22
+        enabled: false
+      banner_cta:
+        weight: 23
+        enabled: false
+      feed:
+        weight: 26
+        enabled: false
+      legislation_attachment:
+        weight: 31
+        enabled: false
+      legislation_cards:
+        weight: 32
+        enabled: false
+      legislation_link:
+        weight: 33
+        enabled: false
+      liftup_box:
+        weight: 34
+        enabled: false
+      liftup_box_item:
+        weight: 35
+        enabled: false
+      liftup_entity_reference:
+        weight: 36
+        enabled: false
+      liftup_entity_reference_item:
+        weight: 37
+        enabled: false
+      liftup_prominent:
+        weight: 38
+        enabled: false
+      link:
+        weight: 39
+        enabled: false
+      view:
+        weight: 42
         enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.paragraph.container_title.field_p_content_unlimited.yml
+++ b/conf/cmi/field.field.paragraph.container_title.field_p_content_unlimited.yml
@@ -17,7 +17,7 @@ bundle: container_title
 label: Content
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -66,13 +66,31 @@ settings:
       highlight_text_box:
         weight: 22
         enabled: false
+      banner_cta:
+        weight: 23
+        enabled: false
       liftup_entity_reference:
         weight: 25
+        enabled: false
+      feed:
+        weight: 26
         enabled: false
       liftup_entity_reference_item:
         enabled: true
         weight: 26
       liftup_prominent:
         weight: 27
+        enabled: false
+      legislation_attachment:
+        weight: 31
+        enabled: false
+      legislation_cards:
+        weight: 32
+        enabled: false
+      legislation_link:
+        weight: 33
+        enabled: false
+      view:
+        weight: 42
         enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/field.field.paragraph.highlight_bullet_point.field_p_content_unlimited.yml
+++ b/conf/cmi/field.field.paragraph.highlight_bullet_point.field_p_content_unlimited.yml
@@ -15,7 +15,7 @@ bundle: highlight_bullet_point
 label: Content
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.paragraph.liftup_entity_reference.field_p_content_unlimited.yml
+++ b/conf/cmi/field.field.paragraph.liftup_entity_reference.field_p_content_unlimited.yml
@@ -15,7 +15,7 @@ bundle: liftup_entity_reference
 label: Content
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.paragraph.liftup_entity_reference_item.field_p_entity_reference.yml
+++ b/conf/cmi/field.field.paragraph.liftup_entity_reference_item.field_p_entity_reference.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - field.storage.paragraph.field_p_entity_reference
     - node.type.article
+    - node.type.community
     - node.type.core_content
+    - node.type.event
     - node.type.legislation_card
     - node.type.legislation_collection_page
     - paragraphs.paragraphs_type.liftup_entity_reference_item
@@ -15,7 +17,7 @@ entity_type: paragraph
 bundle: liftup_entity_reference_item
 label: 'Entity Reference'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
@@ -24,7 +26,9 @@ settings:
   handler_settings:
     target_bundles:
       article: article
+      community: community
       core_content: core_content
+      event: event
       legislation_card: legislation_card
       legislation_collection_page: legislation_collection_page
     sort:

--- a/conf/cmi/field.field.taxonomy_term.theme.field_before_content_paragraphs.yml
+++ b/conf/cmi/field.field.taxonomy_term.theme.field_before_content_paragraphs.yml
@@ -15,7 +15,7 @@ bundle: theme
 label: 'Before content - Paragraphs'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.taxonomy_term.theme.field_paragraphs.yml
+++ b/conf/cmi/field.field.taxonomy_term.theme.field_paragraphs.yml
@@ -15,7 +15,7 @@ bundle: theme
 label: 'After content - Paragraphs'
 description: 'These paragraphs are shown after the dynamic taxonomy term content.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.user.user.field_user_description.yml
+++ b/conf/cmi/field.field.user.user.field_user_description.yml
@@ -13,7 +13,7 @@ bundle: user
 label: Description
 description: 'A brief description of yourself'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.user.user.field_user_title.yml
+++ b/conf/cmi/field.field.user.user.field_user_title.yml
@@ -13,7 +13,7 @@ bundle: user
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/language.content_settings.node.community.yml
+++ b/conf/cmi/language.content_settings.node.community.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.community
 target_entity_type_id: node
 target_bundle: community

--- a/conf/cmi/language.content_settings.node.event.yml
+++ b/conf/cmi/language.content_settings.node.event.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.event
 target_entity_type_id: node
 target_bundle: event

--- a/conf/cmi/language.content_settings.user.user.yml
+++ b/conf/cmi/language.content_settings.user.user.yml
@@ -7,11 +7,11 @@ dependencies:
     - user
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: user.user
 target_entity_type_id: user
 target_bundle: user
 default_langcode: fi
-language_alterable: false
+language_alterable: true

--- a/conf/cmi/views.view.entity_reference_browser.yml
+++ b/conf/cmi/views.view.entity_reference_browser.yml
@@ -84,6 +84,7 @@ display:
             field_article_type: field_article_type
             field_core_content_type: field_core_content_type
             type: type
+            langcode: langcode
           info:
             entity_browser_select:
               align: ''
@@ -112,6 +113,13 @@ display:
               empty_column: true
               responsive: ''
             type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            langcode:
               sortable: true
               default_sort_order: asc
               align: ''
@@ -243,6 +251,137 @@ display:
           entity_type: node
           entity_field: title
           plugin_id: field
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Kieli
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Content type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: type
+          plugin_id: field
         field_article_type:
           id: field_article_type
           table: node__field_article_type
@@ -369,71 +508,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Content type'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
-          settings:
-            link: false
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: node
-          entity_field: type
-          plugin_id: field
       filters:
         status:
           value: '1'
@@ -541,6 +615,53 @@ display:
             group_items: {  }
           entity_type: node
           plugin_id: entity_browser_bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            fi: fi
+            sv: sv
+            en: en
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Kieli
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_producer: '0'
+              editor_in_chief: '0'
+              administrator: '0'
+              webform_administrator: '0'
+            reduce: true
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
       sorts:
         title:
           id: title

--- a/conf/cmi/views.view.entity_reference_browser.yml
+++ b/conf/cmi/views.view.entity_reference_browser.yml
@@ -81,10 +81,10 @@ display:
           columns:
             entity_browser_select: entity_browser_select
             title: title
+            langcode: langcode
+            type: type
             field_article_type: field_article_type
             field_core_content_type: field_core_content_type
-            type: type
-            langcode: langcode
           info:
             entity_browser_select:
               align: ''
@@ -97,6 +97,20 @@ display:
               align: ''
               separator: ''
               empty_column: true
+              responsive: ''
+            langcode:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
               responsive: ''
             field_article_type:
               sortable: true
@@ -112,21 +126,7 @@ display:
               separator: ''
               empty_column: true
               responsive: ''
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            langcode:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: title
+          default: '-1'
           empty_table: false
       row:
         type: fields
@@ -663,20 +663,21 @@ display:
           entity_field: langcode
           plugin_id: language
       sorts:
-        title:
-          id: title
+        published_at:
+          id: published_at
           table: node_field_data
-          field: title
+          field: published_at
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
+          order: DESC
           exposed: false
           expose:
             label: ''
+          granularity: minute
           entity_type: node
-          entity_field: title
-          plugin_id: standard
+          entity_field: published_at
+          plugin_id: date
       header: {  }
       footer: {  }
       empty: {  }

--- a/public/modules/custom/paragraph_translation_migration/paragraph_translation_migration.info.yml
+++ b/public/modules/custom/paragraph_translation_migration/paragraph_translation_migration.info.yml
@@ -1,0 +1,7 @@
+name: Paragraph translation migration
+description: 'Migrates existing paragraph translation to the #2461695 logic.'
+core: '8.x'
+package: Field types
+type: module
+dependencies:
+  - paragraphs

--- a/public/modules/custom/paragraph_translation_migration/paragraph_translation_migration.routing.yml
+++ b/public/modules/custom/paragraph_translation_migration/paragraph_translation_migration.routing.yml
@@ -1,0 +1,7 @@
+paragraph_translation_migration.form_trigger:
+  path: '/admin/paragraph-translation-migration'
+  defaults:
+    _form: 'Drupal\paragraph_translation_migration\Form\ParagraphTranslationMigrationTriggerForm'
+    _title: 'Paragraph Translation'
+  requirements:
+    _permission: 'administer site configuration'

--- a/public/modules/custom/paragraph_translation_migration/src/Form/ParagraphTranslationMigrationTriggerForm.php
+++ b/public/modules/custom/paragraph_translation_migration/src/Form/ParagraphTranslationMigrationTriggerForm.php
@@ -26,13 +26,9 @@ class ParagraphTranslationMigrationTriggerForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Import entities'),
+      '#value' => $this->t('Migrate entities'),
     ];
 
-    $form['paragraph_submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Import paragraphs'),
-    ];
     return $form;
   }
 
@@ -48,21 +44,14 @@ class ParagraphTranslationMigrationTriggerForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // Get all the entities which contain entity reference revisions paragraphs.
-    $entities = \Drupal::getContainer()->get('entity_field.manager')->getFieldMapByFieldType('entity_reference_revisions');
+    $entities = \Drupal::getContainer()
+      ->get('entity_field.manager')
+      ->getFieldMapByFieldType('entity_reference_revisions');
 
     foreach ($entities as $entity_type => $fields) {
       $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type);
-      if ($entity_type->id() !== 'paragraph') {
-        $this->handleMigration($fields, $entity_type);
-      }
+      $this->handleMigration($fields, $entity_type);
     }
-
-    if ($form_state->getTriggeringElement()['#id'] == 'edit-paragraph-submit') {
-      $paragraph_fields = \Drupal::getContainer()->get('entity_field.manager')->getFieldMapByFieldType('entity_reference_revisions')['paragraph'];
-      $type = \Drupal::entityTypeManager()->getDefinition('paragraph');
-      $this->handleMigration($paragraph_fields, $type);
-    }
-
     drupal_set_message('Migration completed.');
   }
 

--- a/public/modules/custom/paragraph_translation_migration/src/Form/ParagraphTranslationMigrationTriggerForm.php
+++ b/public/modules/custom/paragraph_translation_migration/src/Form/ParagraphTranslationMigrationTriggerForm.php
@@ -26,9 +26,13 @@ class ParagraphTranslationMigrationTriggerForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Import'),
+      '#value' => $this->t('Import entities'),
     ];
 
+    $form['paragraph_submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Import paragraphs'),
+    ];
     return $form;
   }
 
@@ -53,9 +57,11 @@ class ParagraphTranslationMigrationTriggerForm extends FormBase {
       }
     }
 
-    $paragraph_fields = \Drupal::getContainer()->get('entity_field.manager')->getFieldMapByFieldType('entity_reference_revisions')['paragraph'];
-    $type = \Drupal::entityTypeManager()->getDefinition('paragraph');
-    $this->handleMigration($paragraph_fields, $type);
+    if ($form_state->getTriggeringElement()['#id'] == 'edit-paragraph-submit') {
+      $paragraph_fields = \Drupal::getContainer()->get('entity_field.manager')->getFieldMapByFieldType('entity_reference_revisions')['paragraph'];
+      $type = \Drupal::entityTypeManager()->getDefinition('paragraph');
+      $this->handleMigration($paragraph_fields, $type);
+    }
 
     drupal_set_message('Migration completed.');
   }

--- a/public/modules/custom/paragraph_translation_migration/src/Form/ParagraphTranslationMigrationTriggerForm.php
+++ b/public/modules/custom/paragraph_translation_migration/src/Form/ParagraphTranslationMigrationTriggerForm.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @file
+ * Definition of paragraph translation migration form.
+ */
+
+namespace Drupal\paragraph_translation_migration\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\paragraphs\Entity\Paragraph;
+
+class ParagraphTranslationMigrationTriggerForm extends FormBase {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'paragraph_translation_migration';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['submit'] = array(
+      '#type' => 'submit',
+      '#value' => $this->t('Import'),
+    );
+
+    return $form;
+  }
+
+  /**
+   * Form submission handler.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Get all the entities which contain entity reference revisions (paragraphs).
+    $entities = \Drupal::getContainer()->get('entity_field.manager')->getFieldMapByFieldType('entity_reference_revisions');
+
+    foreach ($entities as $entity_type => $fields) {
+      $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type);
+      if ($entity_type->id() !== 'paragraph') {
+        $this->handleMigration($fields, $entity_type);
+      }
+    }
+
+    $paragraph_fields = \Drupal::getContainer()->get('entity_field.manager')->getFieldMapByFieldType('entity_reference_revisions')['paragraph'];
+    $type = \Drupal::entityTypeManager()->getDefinition('paragraph');
+    $this->handleMigration($fields, $type);
+
+    drupal_set_message('Migration completed.');
+  }
+
+  private function handleMigration($fields, $entity_type) {
+    foreach ($fields as $field_name => $field) {
+      $field_storage_config = FieldStorageConfig::loadByName($entity_type->id(), $field_name);
+
+      if ($field_storage_config->getSetting('target_type') == 'paragraph') {
+        foreach ($field['bundles'] as $bundle) {
+          $entities = \Drupal::entityTypeManager()->getStorage($entity_type->id())->loadMultiple(\Drupal::entityQuery($entity_type->id())->condition($entity_type->getKey('bundle'), $bundle)->execute());
+          foreach ($entities as $entity) {
+            $translated_languages = $entity->getTranslationLanguages(FALSE);
+            if (!empty($translated_languages)) {
+              foreach ($translated_languages as $language) {
+                $translated_paragraph_entities = [];
+                $paragraph_values = $entity->get($field_name)->getValue();
+                $paragraph_entities = [];
+
+                foreach ($paragraph_values as $item) {
+                  $paragraph_entities[$item['target_revision_id']] = \Drupal::entityTypeManager()->getStorage('paragraph')->loadRevision($item['target_revision_id']);
+                }
+
+                foreach ($paragraph_entities as $paragraph_entity) {
+                  $translated_paragraph_entity = $paragraph_entity->createDuplicate();
+                  if ($translated_paragraph_entity->hasTranslation($language->getId())) {
+                    $translated_paragraph_entity->removeTranslation($language->getId());
+
+                    foreach ($paragraph_entity->getFieldDefinitions() as $paragraph_field) {
+                      if (!in_array($paragraph_field->getName(), ['langcode', 'uuid', 'id', 'default_langcode'])) {
+                        $translated_paragraph_entity->set($paragraph_field->getName(), $paragraph_entity->getTranslation($language->getId())->get($paragraph_field->getName())->getValue());
+                      }
+                    }
+
+                    $translated_paragraph_entity->save();
+                    $translated_paragraph_entities[] = [
+                      'target_id' => $translated_paragraph_entity->id(),
+                      'target_revision_id' => $translated_paragraph_entity->getRevisionId(),
+                    ];
+                  }
+                }
+
+                $translated_entity = $entity->getTranslation($language->getId());
+                $translated_entity->set($field_name, $translated_paragraph_entities);
+                $translated_entity->save();
+                drupal_set_message('Saved ' . $entity->getEntityType()->id() . ', id '. $entity->id() . '. Language: ' . $language->getId() .'. Translated entity id: ' . $translated_entity->id());
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -86,10 +86,10 @@ function suomidigi_preprocess_node(&$variables) {
     $node->getType() === 'legislation_collection_page'
   ) {
     if ($node->hasField('field_header_image')) {
-      $mediaEntity = $node->get('field_header_image')->getValue();
+      $mediaEntity = $node->get('field_header_image')->getString();
 
       if (!empty($mediaEntity)) {
-        $field_media = Media::load($mediaEntity[0]['target_id']);
+        $field_media = Media::load($mediaEntity);
         $mediaImage = $field_media->get('field_media_image')->first();
 
         if (!empty($mediaImage)) {

--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -171,13 +171,13 @@ function suomidigi_preprocess_paragraph(&$variables) {
   switch ($paragraph->getType()) {
     case 'liftup_entity_reference_item':
       if ($paragraph->hasField('field_p_full_width')) {
-        $fullWidthValue = (int) $paragraph->get('field_p_full_width')->getValue()[0]['value'];
+        $fullWidthValue = (int) $paragraph->get('field_p_full_width')->getString();
         $fullWidth = $fullWidthValue === 1 ? TRUE : FALSE;
         $variables['is_full_width'] = $fullWidth;
       }
 
       if ($paragraph->hasField('field_p_entity_reference')) {
-        $targetID = $paragraph->get('field_p_entity_reference')->getValue()[0]['target_id'];
+        $targetID = $paragraph->get('field_p_entity_reference')->getString();
         $is_full_width = &drupal_static('article_full_width_' . $targetID, FALSE);
 
         if (isset($fullWidth) && $fullWidth) {


### PR DESCRIPTION
To test: 
- `make fresh`
- Clear the caches
- Go to https://suomidigi.docker.sh/admin/paragraph-translation-migration 
    1. Click on **Migrate entities**
       - Wait until the migration has completed
       - Clear the caches
    2. Click again on **Migrate entities**
       - Wait until the migration has completed. This fixes missing paragraphs from the first run
- Clear the caches
- Go to English front page https://suomidigi.docker.sh/en
   - Some of the content should still be in Finnish.
   - Edit the page and save it once. 
   - Reload the page and check if the nodes have automatically switched to the translated ones. 
   - Edit the page and remove the ones which are not translated.
   - Check that the front page has updated and switch to FI translation. Check that the page is still intact and none of the references have been removed.
- Go to f.e. https://suomidigi.docker.sh/node/166 and open the english translation in to a new tab
- Compare these two contents and check that the layout is the same (meaning, the paragraphs work)
- Edit the english translation and remove the one of the paragraphs. Check that the original version (fi) stays intact