### PR TITLE
SUOPA-X Language switcher IE fix

### DIFF
--- a/public/themes/custom/suomidigi/src/js/languageSwitcher.js
+++ b/public/themes/custom/suomidigi/src/js/languageSwitcher.js
@@ -1,18 +1,21 @@
+"use strict";
+
 (function ($, Drupal) {
   Drupal.behaviors.languageSwitcher = {
-    attach: function(context) {
-      let languageSwitchToggleButton = $('.language-switch__button', context);
-      let languageSwitchWrapper = $('.language-switch__wrapper', context);
+    attach: function attach(context) {
+      var languageSwitchToggleButton = $('.language-switch__button', context);
+      var languageSwitchWrapper = $('.language-switch__wrapper', context);
 
-      const outsideClickListener = (event) => {
-        let target = $(event.target);
+      var outsideClickListener = function outsideClickListener(event) {
+        var target = $(event.target);
+
         if (!target.closest('.language-switch__wrapper').length && $('.language-switch__wrapper').is(':visible')) {
           handleInteraction(event);
           removeClickListener();
         }
       };
 
-      const removeClickListener = () => {
+      var removeClickListener = function removeClickListener() {
         document.removeEventListener('click', outsideClickListener);
       };
 
@@ -22,8 +25,7 @@
         if (languageSwitchWrapper.hasClass('is-active')) {
           languageSwitchWrapper.removeClass('is-active').attr('aria-hidden', 'true');
           languageSwitchToggleButton.attr('aria-expanded', 'false');
-        }
-        else {
+        } else {
           languageSwitchWrapper.addClass('is-active').attr('aria-hidden', 'false');
           languageSwitchToggleButton.attr('aria-expanded', 'true');
           document.addEventListener('click', outsideClickListener);
@@ -31,13 +33,13 @@
       }
 
       languageSwitchToggleButton.on({
-        touchstart: function(e) {
+        touchstart: function touchstart(e) {
           handleInteraction(e);
         },
-        click: function(e) {
+        click: function click(e) {
           handleInteraction(e);
         },
-        keydown: function (e) {
+        keydown: function keydown(e) {
           if (e.which === 27) {
             languageSwitchWrapper.removeClass('is-active').attr('aria-hidden', 'true');
             languageSwitchToggleButton.attr('aria-expanded', 'false');
@@ -46,5 +48,5 @@
         }
       });
     }
-  }
+  };
 })(jQuery, Drupal);


### PR DESCRIPTION
**To test:** 

- Make fresh
- Open the site in IE 
- Check that the language switcher (on the right side at the top) works properly. It should open the language menu when you click the button. It should look like this: 
![Screenshot 2019-12-11 at 12 10 05](https://user-images.githubusercontent.com/56541345/70612956-85ea4a00-1c10-11ea-934b-b844a05f28c0.png)
- Check that the menu works properly (opens the right language version)

@khalima 