### PR TITLE
SUOPA-717 Liftup 50/50

### DIFF
--- a/conf/cmi/core.entity_form_display.paragraph.liftup_50_50.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.liftup_50_50.default.yml
@@ -1,0 +1,81 @@
+uuid: b156b7ba-e5d8-4c30-868a-603a83c0fb8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.media_browser
+    - field.field.paragraph.liftup_50_50.field_p_content
+    - field.field.paragraph.liftup_50_50.field_p_link
+    - field.field.paragraph.liftup_50_50.field_p_media
+    - field.field.paragraph.liftup_50_50.field_p_reverse
+    - field.field.paragraph.liftup_50_50.field_p_title
+    - paragraphs.paragraphs_type.liftup_50_50
+  module:
+    - entity_browser
+    - link
+    - paragraphs
+id: paragraph.liftup_50_50.default
+targetEntityType: paragraph
+bundle: liftup_50_50
+mode: default
+content:
+  field_p_content:
+    weight: 3
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: text
+      features:
+        duplicate: duplicate
+        collapse_edit_all: collapse_edit_all
+        add_above: '0'
+    third_party_settings: {  }
+    type: paragraphs
+    region: content
+  field_p_link:
+    weight: 1
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_p_media:
+    weight: 2
+    settings:
+      entity_browser: media_browser
+      field_widget_display: rendered_entity
+      field_widget_display_settings:
+        view_mode: media_library
+      field_widget_edit: true
+      field_widget_remove: true
+      selection_mode: selection_append
+      field_widget_replace: false
+      open: false
+    third_party_settings: {  }
+    type: entity_browser_entity_reference
+    region: content
+  field_p_reverse:
+    weight: 4
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_p_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/conf/cmi/core.entity_view_display.paragraph.liftup_50_50.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.liftup_50_50.default.yml
@@ -1,0 +1,69 @@
+uuid: 4b5a2fac-f5ff-4cc7-a5b4-d88496beecc4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.liftup_50_50.field_p_content
+    - field.field.paragraph.liftup_50_50.field_p_link
+    - field.field.paragraph.liftup_50_50.field_p_media
+    - field.field.paragraph.liftup_50_50.field_p_reverse
+    - field.field.paragraph.liftup_50_50.field_p_title
+    - paragraphs.paragraphs_type.liftup_50_50
+  module:
+    - entity_reference_revisions
+    - link
+id: paragraph.liftup_50_50.default
+targetEntityType: paragraph
+bundle: liftup_50_50
+mode: default
+content:
+  field_p_content:
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_p_link:
+    weight: 0
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link_separate
+    region: content
+  field_p_media:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: media_paragraph
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_p_reverse:
+    weight: 4
+    label: hidden
+    settings:
+      format: boolean
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_p_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/conf/cmi/field.field.node.article.field_paragraphs.yml
+++ b/conf/cmi/field.field.node.article.field_paragraphs.yml
@@ -13,6 +13,7 @@ dependencies:
     - paragraphs.paragraphs_type.legislation_attachment
     - paragraphs.paragraphs_type.legislation_cards
     - paragraphs.paragraphs_type.legislation_link
+    - paragraphs.paragraphs_type.liftup_50_50
     - paragraphs.paragraphs_type.liftup_box_item
     - paragraphs.paragraphs_type.liftup_entity_reference_item
   module:
@@ -38,6 +39,7 @@ settings:
       legislation_cards: legislation_cards
       legislation_attachment: legislation_attachment
       contact_information: contact_information
+      liftup_50_50: liftup_50_50
       legislation_link: legislation_link
       contact_information_item: contact_information_item
       group_view: group_view
@@ -103,6 +105,9 @@ settings:
       contact_information:
         enabled: true
         weight: 27
+      liftup_50_50:
+        enabled: true
+        weight: 28
       legislation_link:
         enabled: true
         weight: 28

--- a/conf/cmi/field.field.node.blog_post.field_paragraphs.yml
+++ b/conf/cmi/field.field.node.blog_post.field_paragraphs.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.legislation_attachment
     - paragraphs.paragraphs_type.legislation_cards
     - paragraphs.paragraphs_type.legislation_link
+    - paragraphs.paragraphs_type.liftup_50_50
     - paragraphs.paragraphs_type.liftup_box_item
     - paragraphs.paragraphs_type.liftup_entity_reference_item
   module:
@@ -34,6 +35,7 @@ settings:
       highlight_bullet_point_item: highlight_bullet_point_item
       legislation_cards: legislation_cards
       legislation_attachment: legislation_attachment
+      liftup_50_50: liftup_50_50
       legislation_link: legislation_link
       hero: hero
     target_bundles_drag_drop:
@@ -94,6 +96,9 @@ settings:
       feed:
         weight: 26
         enabled: false
+      liftup_50_50:
+        enabled: true
+        weight: 28
       legislation_link:
         enabled: true
         weight: 28

--- a/conf/cmi/field.field.node.core_content.field_paragraphs.yml
+++ b/conf/cmi/field.field.node.core_content.field_paragraphs.yml
@@ -13,6 +13,7 @@ dependencies:
     - paragraphs.paragraphs_type.legislation_attachment
     - paragraphs.paragraphs_type.legislation_cards
     - paragraphs.paragraphs_type.legislation_link
+    - paragraphs.paragraphs_type.liftup_50_50
     - paragraphs.paragraphs_type.liftup_box_item
     - paragraphs.paragraphs_type.liftup_entity_reference_item
   module:
@@ -38,6 +39,7 @@ settings:
       legislation_cards: legislation_cards
       legislation_attachment: legislation_attachment
       contact_information: contact_information
+      liftup_50_50: liftup_50_50
       legislation_link: legislation_link
       contact_information_item: contact_information_item
       group_view: group_view
@@ -103,6 +105,9 @@ settings:
       contact_information:
         enabled: true
         weight: 27
+      liftup_50_50:
+        enabled: true
+        weight: 28
       legislation_link:
         enabled: true
         weight: 28

--- a/conf/cmi/field.field.node.legislation_collection_page.field_legis_cpage_paragraphs.yml
+++ b/conf/cmi/field.field.node.legislation_collection_page.field_legis_cpage_paragraphs.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.highlight_bullet_point_item
     - paragraphs.paragraphs_type.legislation_attachment
     - paragraphs.paragraphs_type.legislation_link
+    - paragraphs.paragraphs_type.liftup_50_50
     - paragraphs.paragraphs_type.liftup_box_item
     - paragraphs.paragraphs_type.liftup_entity_reference_item
   module:
@@ -38,6 +39,7 @@ settings:
       legislation_link: legislation_link
       contact_information: contact_information
       contact_information_item: contact_information_item
+      liftup_50_50: liftup_50_50
       group_view: group_view
       hero: hero
     target_bundles_drag_drop:
@@ -108,6 +110,9 @@ settings:
         enabled: true
         weight: 27
       contact_information_item:
+        enabled: true
+        weight: 28
+      liftup_50_50:
         enabled: true
         weight: 28
       group_view:

--- a/conf/cmi/field.field.node.page.field_paragraphs.yml
+++ b/conf/cmi/field.field.node.page.field_paragraphs.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.legislation_attachment
     - paragraphs.paragraphs_type.legislation_cards
     - paragraphs.paragraphs_type.legislation_link
+    - paragraphs.paragraphs_type.liftup_50_50
     - paragraphs.paragraphs_type.liftup_box_item
     - paragraphs.paragraphs_type.liftup_entity_reference_item
   module:
@@ -35,6 +36,7 @@ settings:
       legislation_cards: legislation_cards
       legislation_attachment: legislation_attachment
       legislation_link: legislation_link
+      liftup_50_50: liftup_50_50
       hero: hero
     target_bundles_drag_drop:
       container:
@@ -100,6 +102,9 @@ settings:
       legislation_link:
         enabled: true
         weight: -23
+      liftup_50_50:
+        enabled: true
+        weight: 28
       contact_information:
         weight: 29
         enabled: false

--- a/conf/cmi/field.field.paragraph.liftup_50_50.field_p_content.yml
+++ b/conf/cmi/field.field.paragraph.liftup_50_50.field_p_content.yml
@@ -1,0 +1,111 @@
+uuid: 2e808f0a-a66a-434f-92d6-ae5a7e989970
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_content
+    - paragraphs.paragraphs_type.liftup_50_50
+    - paragraphs.paragraphs_type.list_of_links
+    - paragraphs.paragraphs_type.text
+  module:
+    - entity_reference_revisions
+id: paragraph.liftup_50_50.field_p_content
+field_name: field_p_content
+entity_type: paragraph
+bundle: liftup_50_50
+label: Content
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      list_of_links: list_of_links
+      text: text
+    target_bundles_drag_drop:
+      liftup_50_50:
+        weight: 28
+        enabled: false
+      attachment:
+        weight: 29
+        enabled: false
+      banner_cta:
+        weight: 30
+        enabled: false
+      contact_information:
+        weight: 31
+        enabled: false
+      contact_information_item:
+        weight: 32
+        enabled: false
+      container:
+        weight: 33
+        enabled: false
+      container_title:
+        weight: 34
+        enabled: false
+      feed:
+        weight: 35
+        enabled: false
+      group_view:
+        weight: 36
+        enabled: false
+      hero:
+        weight: 37
+        enabled: false
+      highlight_bullet_point:
+        weight: 38
+        enabled: false
+      highlight_bullet_point_item:
+        weight: 39
+        enabled: false
+      highlight_cta:
+        weight: 40
+        enabled: false
+      highlight_text_box:
+        weight: 41
+        enabled: false
+      legislation_attachment:
+        weight: 42
+        enabled: false
+      legislation_cards:
+        weight: 43
+        enabled: false
+      legislation_link:
+        weight: 44
+        enabled: false
+      liftup_box:
+        weight: 45
+        enabled: false
+      liftup_box_item:
+        weight: 46
+        enabled: false
+      liftup_entity_reference:
+        weight: 47
+        enabled: false
+      liftup_entity_reference_item:
+        weight: 48
+        enabled: false
+      liftup_prominent:
+        weight: 49
+        enabled: false
+      link:
+        weight: 50
+        enabled: false
+      list_of_links:
+        enabled: true
+        weight: 51
+      media:
+        weight: 52
+        enabled: false
+      text:
+        enabled: true
+        weight: 53
+      view:
+        weight: 54
+        enabled: false
+field_type: entity_reference_revisions

--- a/conf/cmi/field.field.paragraph.liftup_50_50.field_p_link.yml
+++ b/conf/cmi/field.field.paragraph.liftup_50_50.field_p_link.yml
@@ -1,0 +1,23 @@
+uuid: 77348146-0e8a-45a7-ba10-09cfd57eb0d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_link
+    - paragraphs.paragraphs_type.liftup_50_50
+  module:
+    - link
+id: paragraph.liftup_50_50.field_p_link
+field_name: field_p_link
+entity_type: paragraph
+bundle: liftup_50_50
+label: Link
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/conf/cmi/field.field.paragraph.liftup_50_50.field_p_media.yml
+++ b/conf/cmi/field.field.paragraph.liftup_50_50.field_p_media.yml
@@ -1,0 +1,30 @@
+uuid: 7697b7c4-6f14-4657-a605-ca9813a19d2d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_media
+    - media.type.image
+    - media.type.video
+    - paragraphs.paragraphs_type.liftup_50_50
+id: paragraph.liftup_50_50.field_p_media
+field_name: field_p_media
+entity_type: paragraph
+bundle: liftup_50_50
+label: Media
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+      video: video
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: image
+field_type: entity_reference

--- a/conf/cmi/field.field.paragraph.liftup_50_50.field_p_reverse.yml
+++ b/conf/cmi/field.field.paragraph.liftup_50_50.field_p_reverse.yml
@@ -1,0 +1,23 @@
+uuid: fe63dce2-b7a1-4148-910f-2c8ed3d4ca46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_reverse
+    - paragraphs.paragraphs_type.liftup_50_50
+id: paragraph.liftup_50_50.field_p_reverse
+field_name: field_p_reverse
+entity_type: paragraph
+bundle: liftup_50_50
+label: Reverse
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.field.paragraph.liftup_50_50.field_p_title.yml
+++ b/conf/cmi/field.field.paragraph.liftup_50_50.field_p_title.yml
@@ -1,0 +1,19 @@
+uuid: 84e9d7b1-265e-42e0-90c6-f959701b1a89
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_title
+    - paragraphs.paragraphs_type.liftup_50_50
+id: paragraph.liftup_50_50.field_p_title
+field_name: field_p_title
+entity_type: paragraph
+bundle: liftup_50_50
+label: TItle
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/image.style.thumbnail.yml
+++ b/conf/cmi/image.style.thumbnail.yml
@@ -1,17 +1,19 @@
 uuid: c80a7a8d-3e84-47b7-b277-742201a479ab
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 _core:
   default_config_hash: cCiWdBHgLwj5omG35lsKc4LkW4MBdmcctkVop4ol5x0
 name: thumbnail
 label: 'Thumbnail (100 × 100)'
 effects:
-  1cfec298-8620-4749-b100-ccb6c4500779:
-    uuid: 1cfec298-8620-4749-b100-ccb6c4500779
-    id: image_scale
-    weight: 0
+  dae5a494-20b2-44d9-ba08-8bdff6b3bc38:
+    uuid: dae5a494-20b2-44d9-ba08-8bdff6b3bc38
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 100
       height: 100
-      upscale: false
+      crop_type: focal_point

--- a/conf/cmi/paragraphs.paragraphs_type.liftup_50_50.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.liftup_50_50.yml
@@ -1,0 +1,9 @@
+uuid: c8779809-3309-45a2-a7a7-499df0882138
+langcode: en
+status: true
+dependencies: {  }
+id: liftup_50_50
+label: 'Liftup 50/50'
+icon_uuid: null
+description: ''
+behavior_plugins: {  }

--- a/public/modules/custom/suopa_dream_broker/src/Controller/DreamBrokerOembedController.php
+++ b/public/modules/custom/suopa_dream_broker/src/Controller/DreamBrokerOembedController.php
@@ -85,15 +85,16 @@ class DreamBrokerOembedController extends ControllerBase {
       return new JsonResponse($this->getResults());
     }
 
-    return new JsonResponse(FALSE);
+    return new JsonResponse([]);
   }
 
   /**
    * A helper function for returning results.
    */
   private function getResults() {
+    $url = 'https://dreambroker.com/channel/' . $this->channelId . '/iframe/' . $this->videoId;
     return [
-      'html' => '<iframe width="480" height="270" src="' . $this->dreamBrokerUrl . '" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen</iframe>',
+      'html' => '<iframe width="480" height="270" src="' . $url . '" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen</iframe>',
       'height' => 270,
       'type' => 'video',
       'thumbnail_width' => 480,
@@ -112,7 +113,7 @@ class DreamBrokerOembedController extends ControllerBase {
    */
   private function getIdFromInput() {
     $matches = [];
-    preg_match('/(?:channel\/([a-z0-9]{8}))\/(?:iframe\/([a-z0-9]{8}))/', $this->dreamBrokerUrl, $matches);
+    preg_match('/(?:channel\/([a-z0-9]{8}))\/([a-z0-9]{8})/', $this->dreamBrokerUrl, $matches);
 
     if ($matches && !empty($matches[1]) && !empty($matches[2])) {
       return [$matches[1], $matches[2]];

--- a/public/themes/custom/suomidigi/src/scss/base/_typography.scss
+++ b/public/themes/custom/suomidigi/src/scss/base/_typography.scss
@@ -46,11 +46,13 @@
 
 // ########## General ########## //
 body {
-  @include font-size($font-size-body, $font-size-mobile-body);
-  @include line-height($font-size-body, $font-line-height-body, $font-size-mobile-body, $font-line-height-body);
+  @include font-size($font-size-mobile-body, $font-line-height-mobile-body);
   color: $black;
   font-family: $default-font-family;
   font-weight: 200;
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-body, $font-line-height-body);
+  }
 }
 
 a {
@@ -91,51 +93,72 @@ h6 {
 }
 
 h1 {
-  @include font-size($font-size-heading-1, $font-size-mobile-heading-1);
-  @include line-height($font-size-heading-1, $font-line-height-heading-1, $font-size-mobile-heading-1, $font-line-height-mobile-heading-1);
+  @include font-size($font-size-mobile-heading-1, $font-line-height-mobile-heading-1);
   margin-bottom: 2rem;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-heading-1, $font-line-height-heading-1);
+  }
 }
 
 h2 {
-  @include font-size($font-size-heading-2, $font-size-mobile-heading-2);
-  @include line-height($font-size-heading-2, $font-line-height-heading-2, $font-size-mobile-heading-2, $font-line-height-mobile-heading-2);
+  @include font-size($font-size-mobile-heading-2, $font-line-height-mobile-heading-2);
   margin-bottom: 1.25rem;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-heading-2, $font-line-height-heading-2);
+  }
 }
 
 h3 {
-  @include font-size($font-size-heading-3, $font-size-mobile-heading-3);
-  @include line-height($font-size-heading-3, $font-line-height-heading-3, $font-size-mobile-heading-3, $font-line-height-mobile-heading-3);
+  @include font-size($font-size-mobile-heading-3, $font-line-height-mobile-heading-3);
   @include font-weight($semibold);
   margin-bottom: 1rem;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-heading-3, $font-line-height-heading-3);
+  }
 }
 
 h4 {
-  @include font-size($font-size-heading-4, $font-size-mobile-heading-4);
-  @include line-height($font-size-heading-4, $font-line-height-heading-4, $font-size-mobile-heading-4, $font-line-height-mobile-heading-4);
+  @include font-size($font-size-mobile-heading-4, $font-line-height-mobile-heading-4);
   @include font-weight($semibold);
   margin-bottom: .75rem;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-heading-4, $font-line-height-heading-4);
+  }
 }
 
 h5 {
-  @include font-size($font-size-heading-5, $font-size-mobile-heading-5);
-  @include line-height($font-size-heading-5, $font-line-height-heading-5, $font-size-mobile-heading-5, $font-line-height-mobile-heading-5);
+  @include font-size($font-size-mobile-heading-5, $font-line-height-mobile-heading-5);
   @include font-weight($semibold);
   margin-bottom: .5rem;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-heading-5, $font-line-height-heading-5);
+  }
 }
 
 h6 {
-  @include font-size($font-size-heading-6, $font-size-mobile-heading-6);
-  @include line-height($font-size-heading-6, $font-line-height-heading-6, $font-size-mobile-heading-6, $font-line-height-mobile-heading-6);
+  @include font-size($font-size-mobile-heading-6, $font-line-height-mobile-heading-6);
   @include font-weight($semibold);
   margin-bottom: .25rem;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-heading-6, $font-line-height-heading-6);
+  }
 }
 
 p {
-  @include font-size($font-size-body, $font-size-mobile-body);
-  @include line-height($font-size-body, $font-line-height-body, $font-size-mobile-body, $font-line-height-body);
+  @include font-size($font-size-mobile-body, $font-line-height-body);
   @include font-weight($regular);
   margin-bottom: 1rem;
   margin-top: 0;
+
+  @include breakpoint($for-tablet-portrait-up) {
+    @include font-size($font-size-body, $font-line-height-body);
+  }
 }
 
 p,

--- a/public/themes/custom/suomidigi/src/scss/components/branding/_logo.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/branding/_logo.scss
@@ -15,8 +15,7 @@
   }
 
   &--text {
-    @include font-size(32px);
-    @include line-height(32px, 40px);
+    @include font-size(32px, 40px);
     color: $blue;
     font-family: $default-font-family;
     font-weight: bold;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_article-teaser.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_article-teaser.scss
@@ -86,8 +86,7 @@
 }
 
 .article-teaser__data {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   @include font-weight($semibold);
   color: $black;
   display: flex;
@@ -123,15 +122,13 @@
 }
 
 .article-teaser__label-container {
-  @include font-size(20px);
-  @include line-height(20px, 24px);
+  @include font-size(20px, 24px);
   color: $blue-medium;
   margin: $gutter * 0.5 0;
   overflow-wrap: break-word;
 
   @include breakpoint($for-tablet-portrait-up) {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     margin: $gutter * 0.5 0 $gutter;
   }
 
@@ -145,8 +142,7 @@
   color: $blue;
 
   .listing--grid & {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     @include font-weight($semibold);
 
     &:hover {
@@ -156,16 +152,14 @@
 }
 
 .article-teaser__lead {
-  @include font-size(18px);
-  @include line-height(18px, 26px);
+  @include font-size(18px, 26px);
   @include font-weight($regular);
   color: $black;
   letter-spacing: 0;
 }
 
 .article-teaser__type {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   @include font-weight($semibold);
   border-top: 1px solid $gray-medium;
   color: $black;
@@ -224,8 +218,7 @@
     }
 
     .article-teaser__label {
-      @include font-size(22px);
-      @include line-height(22px, 28px);
+      @include font-size(22px, 28px);
       @include font-weight($semibold);
       color: $blue;
     }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_article.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_article.scss
@@ -3,8 +3,7 @@
 }
 
 .article__type {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   @include font-weight($semibold);
   margin-bottom: $gutter;
   width: 100%;
@@ -19,8 +18,7 @@
 
 .article__title {
   h1 {
-    @include font-size(26px);
-    @include line-height(26px, 33px);
+    @include font-size(26px, 33px);
     @include font-weight($bold);
     color: $blue-medium;
     margin-bottom: $gutter;
@@ -28,8 +26,7 @@
 }
 
 .article__lead {
-  @include font-size(20px);
-  @include line-height(20px, 26px);
+  @include font-size(20px, 26px);
   @include font-weight($regular);
   margin-bottom: $gutter;
 
@@ -39,8 +36,7 @@
 }
 
 .article__data {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   color: $black;
   display: flex;
   flex-wrap: wrap;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_attachment.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_attachment.scss
@@ -1,6 +1,6 @@
 .attachment-teaser {
-  margin: $gutter / 2;
   border: 1px solid $gray;
+  margin: $gutter / 2;
   padding: $gutter / 2;
   width: 100%;
 
@@ -19,16 +19,15 @@
   }
 
   &__title {
-    @include font-size(16px);
-    @include line-height(20px, 16px);
+    @include font-size(16px, 20px);
     font-weight: 600;
     margin-bottom: 0;
   }
 
   &__file-type {
     color: $gray-dark;
-    text-transform: uppercase;
     margin-bottom: 0;
+    text-transform: uppercase;
   }
 
   &__link {

--- a/public/themes/custom/suomidigi/src/scss/components/content/_author.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_author.scss
@@ -1,7 +1,6 @@
 .author {
   &__label {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     border-bottom: 1px solid $gray-medium;
     color: $blue-medium;
     letter-spacing: 0;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_basic-page-teaser.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_basic-page-teaser.scss
@@ -34,15 +34,13 @@
 
 
 .basic-page-teaser__label-container {
-  @include font-size(20px);
-  @include line-height(20px, 24px);
+  @include font-size(20px, 24px);
   color: $blue-medium;
   margin: $gutter * 0.5 0;
   overflow-wrap: break-word;
 
   @include breakpoint($for-tablet-portrait-up) {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     margin: $gutter * 0.5 0 $gutter;
   }
 
@@ -56,8 +54,7 @@
 }
 
 .basic-page-teaser__type {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   @include font-weight($semibold);
   border-top: 1px solid $gray-medium;
   color: $black;
@@ -79,8 +76,7 @@
 }
 
 .basic-page-teaser__lead {
-  @include font-size(18px);
-  @include line-height(18px, 26px);
+  @include font-size(18px, 26px);
   @include font-weight($regular);
   color: $black;
   letter-spacing: 0;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_basic-page.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_basic-page.scss
@@ -5,16 +5,14 @@
 .basic-page__title {
   h1 {
     color: $blue-medium;
-    @include font-size(26px);
-    @include line-height(26px, 33px);
+    @include font-size(26px, 33px);
     @include font-weight($bold);
     margin-bottom: $gutter;
   }
 }
 
 .basic-page__lead {
-  @include font-size(20px);
-  @include line-height(20px, 26px);
+  @include font-size(20px, 26px);
   @include font-weight($regular);
   margin-bottom: $gutter;
 
@@ -24,8 +22,7 @@
 }
 
 .basic-page__data {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   color: $black;
   display: flex;
   flex-wrap: wrap;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_blog-teaser.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_blog-teaser.scss
@@ -65,15 +65,13 @@
 }
 
 .blog-teaser__date {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   @include font-weight($semibold);
   color: $black;
 }
 
 .blog-teaser__label {
-  @include font-size(22px);
-  @include line-height(22px, 28px);
+  @include font-size(22px, 28px);
   @include font-weight($semibold);
   color: $blue;
   letter-spacing: 0;
@@ -86,8 +84,7 @@
 }
 
 .blog-teaser__lead {
-  @include font-size(18px);
-  @include line-height(18px, 26px);
+  @include font-size(18px, 26px);
   @include font-weight($regular);
   color: $black;
   margin: 0;
@@ -99,8 +96,7 @@
 }
 
 .blog-teaser__author {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   @include font-weight($semibold);
   color: $blue-light;
 
@@ -112,8 +108,7 @@
   }
 
   .author__label {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     @include font-weight($semibold);
     border: 0 none;
     color: $black;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_blog.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_blog.scss
@@ -42,8 +42,8 @@
 }
 
 .blog__type {
-  font-weight: 600;
-  line-height: 100%;
+  @include font-size(16px, 16px);
+  @include font-weight($semibold);
   margin-bottom: 0.25rem;
   width: 100%;
 

--- a/public/themes/custom/suomidigi/src/scss/components/content/_comments.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_comments.scss
@@ -22,35 +22,35 @@
   }
 
   &__meta {
-    display: flex;
     align-items: center;
+    display: flex;
   }
 
   &__avatar {
     align-content: center;
     display: flex;
-    margin-right: $gutter;
     justify-content: center;
+    margin-right: $gutter;
 
     img {
       border-radius: 2px;
-      min-width: $gutter * 3;
-      min-height: $gutter * 3;
       max-width: $gutter * 3;
+      min-height: $gutter * 3;
+      min-width: $gutter * 3;
     }
 
     &--letter {
       @include font-size(24px);
+      @include font-weight($bold);
       align-items: center;
       background-color: $blue-medium;
       border-radius: 2px;
       color: $white;
       display: flex;
-      font-weight: bold;
       height: $gutter * 3;
       justify-content: center;
-      text-transform: uppercase;
       text-decoration: none;
+      text-transform: uppercase;
       width: $gutter * 3;
 
       .community__link:hover & {

--- a/public/themes/custom/suomidigi/src/scss/components/content/_community.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_community.scss
@@ -46,8 +46,7 @@
   }
 
   &__domain {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     @include font-weight($semibold);
     color: $black;
     margin-bottom: 0;
@@ -56,16 +55,14 @@
 
   &__title {
     color: $blue-medium;
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     @include font-weight($semibold);
     margin-bottom: $gutter;
   }
 
   &__content,
   &__content p {
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
     color: $black;
   }
 
@@ -90,8 +87,7 @@
 
   &__cta {
     display: flex;
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
     @include font-weight($semibold);
     margin-top: $gutter;
     transition: all 150ms linear;
@@ -110,15 +106,13 @@
     @include border();
 
     &-title {
-      @include font-size(22px);
-      @include line-height(22px, 28px);
+      @include font-size(22px, 28px);
       @include font-weight($semibold);
       color: $blue;
     }
 
     &-description {
-      @include font-size(18px);
-      @include line-height(18px, 26px);
+      @include font-size(18px, 26px);
       @include font-weight($regular);
       color: $black;
       margin-bottom: 25px;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_core-content-teaser.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_core-content-teaser.scss
@@ -54,33 +54,29 @@
   }
 
   &__label {
-    @include font-size(20px);
+    @include font-size(20px, 20px);
     font-weight: 600;
-    line-height: 100%;
     margin-bottom: 0;
   }
 
   &__lead {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     color: $gray-darker;
     margin-bottom: $gutter;
     word-break: break-word;
   }
 
   &__type {
-    @include font-size(14px);
+    @include font-size(14px, 14px);
     color: $gray-darker;
     display: block;
     font-weight: 600;
-    line-height: 100%;
   }
 
   &__label-type {
-    @include font-size(12px);
+    @include font-size(12px, 12px);
     color: $gray-darker;
     display: none;
-    line-height: 100%;
     margin-top: $gutter * 0.35;
   }
 

--- a/public/themes/custom/suomidigi/src/scss/components/content/_core-content.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_core-content.scss
@@ -1,9 +1,8 @@
 .core-content {
 
   &__published {
-    @include font-size(14px);
+    @include font-size(14px, 14px);
     color: $gray-darker;
-    line-height: 100%;
   }
 
   .article__header.is-empty {

--- a/public/themes/custom/suomidigi/src/scss/components/content/_event-teaser.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_event-teaser.scss
@@ -12,8 +12,7 @@
   }
 
   h3 {
-    @include font-size(18px);
-    @include line-height(18px, 23px);
+    @include font-size(18px, 23px);
     @include font-weight($semibold);
     color: $black;
   }
@@ -41,8 +40,7 @@
   }
 
   &__title {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     @include font-weight($semibold);
     color: $blue;
     margin-bottom: $gutter;
@@ -54,8 +52,7 @@
 
   &__description,
   &__description p {
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
     @include font-weight($regular);
     margin-bottom: 0.5rem;
   }
@@ -75,8 +72,7 @@
     }
 
     &--date {
-      @include font-size(16px);
-      @include line-height(16px, 20px);
+      @include font-size(16px, 20px);
       @include font-weight($semibold);
       color: $black;
     }
@@ -96,8 +92,7 @@
     }
 
     &--wrapper {
-      @include font-size(16px);
-      @include line-height(16px, 20px);
+      @include font-size(16px, 20px);
       @include font-weight($semibold);
       display: flex;
       flex-wrap: wrap;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_event.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_event.scss
@@ -8,8 +8,7 @@
   }
 
   h3 {
-    @include font-size(18px);
-    @include line-height(18px, 23px);
+    @include font-size(18px, 23px);
     @include font-weight($semibold);
     color: $black;
   }
@@ -58,9 +57,8 @@
     }
 
     .page-title {
-      @include font-size(26px);
+      @include font-size(26px, 33px);
       @include font-weight($bold);
-      @include line-height(26px, 33px);
       color: $blue-medium;
     }
   }
@@ -75,8 +73,7 @@
 
   &__description,
   &__description p {
-    @include font-size(20px);
-    @include line-height(20px, 26px);
+    @include font-size(20px, 26px);
   }
 
   &__registration {
@@ -100,8 +97,7 @@
     }
 
     &--date {
-      @include font-size(18px);
-      @include line-height(18px, 23px);
+      @include font-size(18px, 23px);
       @include font-weight($semibold);
       color: $black;
     }
@@ -130,8 +126,7 @@
   }
 
   &__address {
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
     @include font-weight($regular);
     color: $black;
     flex-basis: 100%;
@@ -152,42 +147,36 @@
   }
 
   &__free-text {
-    @include font-size(16px);
-    @include line-height(16px, 20px);
+    @include font-size(16px, 20px);
     @include font-weight($regular);
     color: $black;
     margin-bottom: $gutter;
 
     h2 {
-      @include font-size(22px);
-      @include line-height(22px, 20px);
+      @include font-size(22px, 20px);
       @include font-weight($semibold);
     }
   }
 
   &__venue-description,
   &__venue-description p {
-    @include font-size(14px);
-    @include line-height(14px, 20px);
+    @include font-size(14px, 20px);
     @include font-weight($regular);
     margin-bottom: $gutter * 2;
 
     .field__label {
-      @include font-size(18px);
-      @include line-height(18px, 23px);
+      @include font-size(18px, 23px);
       @include font-weight($semibold);
       margin-bottom: $gutter;
     }
   }
 
   &__contact-info {
-    @include font-size(14px);
-    @include line-height(14px, 20px);
+    @include font-size(14px, 20px);
     @include font-weight($regular);
 
     .field__label {
-      @include font-size(18px);
-      @include line-height(18px, 23px);
+      @include font-size(18px, 23px);
       @include font-weight($semibold);
       margin-bottom: $gutter;
     }
@@ -198,15 +187,13 @@
       margin-bottom: $gutter;
 
       .name {
-        @include font-size(14px);
-        @include line-height(14px, 20px);
+        @include font-size(14px, 20px);
         @include font-weight($semibold);
       }
 
       .email,
       .phone-number {
-        @include font-size(14px);
-        @include line-height(14px, 20px);
+        @include font-size(14px, 20px);
         @include font-weight($regular);
       }
     }
@@ -214,15 +201,13 @@
 
   &__organiser {
     &--name {
-      @include font-size(16px);
-      @include line-height(16px, 24px);
+      @include font-size(16px, 24px);
       @include font-weight($semibold);
       margin-bottom: $gutter;
     }
 
     &--description {
-      @include font-size(14px);
-      @include line-height(14px, 20px);
+      @include font-size(14px, 20px);
       @include font-weight($regular);
       margin-bottom: $gutter;
     }
@@ -259,8 +244,7 @@
     }
 
     &--text {
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       @include font-weight($semibold);
       text-decoration: none;
     }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_group.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_group.scss
@@ -30,14 +30,12 @@
   }
 
   &__title {
-    @include font-size(26px);
-    @include line-height(26px, 33px);
+    @include font-size(26px, 33px);
     @include font-weight($bold);
   }
 
   &__description {
-    @include font-size(20px);
-    @include line-height(20px, 28px);
+    @include font-size(20px, 28px);
     @include font-weight($regular);
     min-height: 50px;
   }
@@ -79,22 +77,19 @@
   }
 
   &__content {
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
     @include font-weight($regular);
     color: $black;
     width: 100%;
 
     h2 {
-      @include font-size(22px);
-      @include line-height(22px, 28px);
+      @include font-size(22px, 28px);
       @include font-weight($semibold);
       color: $blue;
     }
 
     p {
-      @include font-size(18px);
-      @include line-height(18px, 26px);
+      @include font-size(18px, 26px);
       @include font-weight($regular);
     }
 
@@ -236,8 +231,7 @@
       }
 
       .group__description {
-        @include font-size(18px);
-        @include line-height(18px, 26px);
+        @include font-size(18px, 26px);
         @include font-weight($regular);
         flex-grow: 1;
         height: auto;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_landing-page.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_landing-page.scss
@@ -2,16 +2,14 @@
   padding-bottom: $gutter * 2;
 
   &__slogan {
-    @include font-size(20px);
-    @include line-height(20px, 26px);
+    @include font-size(20px, 26px);
     @include font-weight($regular);
     color: $black;
   }
 
   &__ingress {
     color: $black;
-    @include font-size(20px);
-    @include line-height(20px, 26px);
+    @include font-size(20px, 26px);
     @include font-weight($regular);
     margin-bottom: $gutter * 2;
     max-width: 650px;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_legislation-attachment.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_legislation-attachment.scss
@@ -5,8 +5,8 @@
   padding: $gutter / 2;
 
   &__wrapper {
-    display: flex;
     align-items: center;
+    display: flex;
   }
 
   &__link,
@@ -15,14 +15,13 @@
   }
 
   &__icon {
+    height: $gutter * 2;
     margin-right: $gutter;
     width: $gutter * 2;
-    height: $gutter * 2;
   }
 
   &__title {
-    @include font-size(18px);
-    @include line-height(18px, 18px);
+    @include font-size(18px, 18px);
     color: $black;
     font-weight: 600;
     margin-bottom: $gutter / 4;
@@ -33,23 +32,21 @@
   }
 
   &__file-type {
-    @include font-size(12px);
-    @include line-height(14px, 12px);
+    @include font-size(14px, 12px);
     color: $gray-dark;
     font-weight: 600;
-    text-transform: uppercase;
     margin-bottom: 0;
+    text-transform: uppercase;
   }
 
   &__file-size {
     color: $gray-dark;
-    text-transform: uppercase;
     margin-bottom: 0;
+    text-transform: uppercase;
   }
 
   &__cta {
-    @include font-size(12px);
-    @include line-height(12px, 12px);
+    @include font-size(12px, 12px);
     background-color: $white;
     border: 1px solid $legislation-blue;
     color: $legislation-blue;

--- a/public/themes/custom/suomidigi/src/scss/components/content/_legislation-card.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_legislation-card.scss
@@ -9,8 +9,7 @@
   }
 
   &__title {
-    @include font-size(18px);
-    @include line-height(18px, 18px);
+    @include font-size(18px, 18px);
     color: $legislation-blue;
     font-weight: bold;
     padding: 0 0 $gutter;
@@ -21,19 +20,16 @@
   }
 
   &__ingress {
-    @include font-size(18px);
-    @include line-height(18px, 18px);
+    @include font-size(18px, 18px);
     padding: 0 0 $gutter;
   }
 
   &__content {
-    @include font-size(18px);
-    @include line-height(18px, 18px);
+    @include font-size(18px, 18px);
     padding: 0 0 $gutter * 2;
 
     p {
-      @include font-size(18px);
-      @include line-height(18px, 18px);
+      @include font-size(18px, 18px);
 
       &:last-of-type {
         margin-bottom: 0;
@@ -49,8 +45,7 @@
     padding: 0 0 $gutter * 2;
 
     &__title {
-      @include font-size(18px);
-      @include line-height(18px, 18px);
+      @include font-size(18px, 18px);
       font-weight: bold;
       padding-bottom: $gutter / 2;
     }
@@ -58,8 +53,8 @@
 
   &--teaser {
     background-color: $white;
-    margin-bottom: 0;
     border-bottom: 0 none;
+    margin-bottom: 0;
     transition: all 50ms cubic-bezier(0.28, 0.84, 0.42, 1) 0s;
 
     &:last-of-type {
@@ -75,14 +70,12 @@
     }
 
     .legislation-card__breadcrumb {
-      @include font-size(12px);
-      @include line-height(12px, 12px);
+      @include font-size(12px, 12px);
       color: $gray-darkest;
       margin-bottom: $gutter / 2;
 
       .divider {
-        @include font-size(15px);
-        @include line-height(15px, 15px);
+        @include font-size(15px, 15px);
         color: $black;
         font-weight: 600;
       }
@@ -95,9 +88,9 @@
       padding: 0;
 
       &--icon {
+        height: 20px;
         margin-left: auto;
         width: 20px;
-        height: 20px;
       }
     }
 

--- a/public/themes/custom/suomidigi/src/scss/components/content/_legislation-collection.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_legislation-collection.scss
@@ -2,16 +2,14 @@
   padding-bottom: $gutter * 2;
 
   &__ingress {
-    @include font-size(14px);
-    @include line-height(14px, 20px);
+    @include font-size(14px, 20px);
     color: $black;
     margin-bottom: $gutter * 2;
     text-align: center;
   }
 
   &__toggle-button {
-    @include font-size(18px);
-    @include line-height(18px, 18px);
+    @include font-size(18px, 18px);
     background: transparent;
     border: 0 none;
     color: $legislation-blue;
@@ -27,8 +25,7 @@
   }
 
   &__label {
-    @include font-size(18px);
-    @include line-height(18px, 18px);
+    @include font-size(18px, 18px);
     color: $black;
     font-weight: bold;
     margin-bottom: $gutter;
@@ -101,8 +98,7 @@
     }
 
     &__label {
-      @include font-size(22px);
-      @include line-height(22px, 24px);
+      @include font-size(22px, 24px);
       color: $black;
       font-weight: 800;
       margin: 0;
@@ -122,7 +118,7 @@
 
 
     &__lead {
-      @include line-height(14px, 22px);
+      @include font-size(14px, 22px);
       color: $black;
       margin: 0;
     }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_legislation-link.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_legislation-link.scss
@@ -5,8 +5,8 @@
   padding: $gutter / 2;
 
   &__content {
-    display: flex;
     align-items: center;
+    display: flex;
   }
 
   &__link,
@@ -19,8 +19,7 @@
   }
 
   &__title {
-    @include font-size(18px);
-    @include line-height(18px, 18px);
+    @include font-size(18px, 18px);
     color: $black;
     font-weight: 600;
     margin-bottom: $gutter / 4;
@@ -31,17 +30,15 @@
   }
 
   &__destination {
-    @include font-size(10px);
-    @include line-height(10px, 10px);
+    @include font-size(10px, 10px);
     color: $gray-dark;
     font-weight: 600;
-    text-transform: uppercase;
     margin-bottom: 0;
+    text-transform: uppercase;
   }
 
   &__cta {
-    @include font-size(12px);
-    @include line-height(12px, 12px);
+    @include font-size(12px, 12px);
     background-color: $white;
     border: 1px solid $legislation-blue;
     color: $legislation-blue;
@@ -60,8 +57,7 @@
   }
 
   &__description {
-    @include font-size(12px);
-    @include line-height(12px, 16px);
+    @include font-size(12px, 16px);
     color: $black;
     margin-top: $gutter * 0.75;
   }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_media-image.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_media-image.scss
@@ -5,14 +5,13 @@
   }
 
   &__creator {
-    @include font-size(12px);
-    @include line-height(12px, 12px);
+    @include font-size(12px, 12px);
     background-color: $white;
     color: lighten($black, 5%);
+    padding: 4px 6px;
     position: absolute;
     right: 0;
     top: 0;
-    padding: 4px 6px;
 
     &--label {
     }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_page-title.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_page-title.scss
@@ -23,17 +23,24 @@
     color: $blue;
 
     &.page-title--alternative {
-      @include font-size(32px, 24px);
-      @include line-height(32px, 32px, 24px, 24px);
-      font-weight: normal;
+      @include font-size(24px, 24px);
+      @include font-weight($regular);
       text-transform: uppercase;
+
+      @include breakpoint($for-tablet-portrait-up) {
+        @include font-size(32px, 32px);
+      }
     }
 
     &.page-title--secondary {
-      @include font-size(32px, 24px);
-      @include line-height(32px, 32px, 24px, 24px);
-      font-weight: bold;
+      @include font-size(24px, 24px);
+      @include font-weight($semibold);
       letter-spacing: -0.02rem;
+      text-transform: uppercase;
+
+      @include breakpoint($for-tablet-portrait-up) {
+        @include font-size(32px, 32px);
+      }
     }
 
     .page-before_content--user & {

--- a/public/themes/custom/suomidigi/src/scss/components/content/_theme-term.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_theme-term.scss
@@ -47,8 +47,7 @@
   }
 
   &__description {
-    @include font-size(22px);
-    @include line-height(22px, 30px);
+    @include font-size(22px, 30px);
     @include font-weight($regular);
     margin-bottom: $gutter * 2;
   }

--- a/public/themes/custom/suomidigi/src/scss/components/content/_twitter.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_twitter.scss
@@ -1,6 +1,5 @@
 .tweet {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   background-color: $white;
   height: 100%;
   padding: $gutter;
@@ -36,15 +35,13 @@
     margin-left: 10px;
 
     h3 {
-      @include font-size(18px);
-      @include line-height(18px, 23px);
+      @include font-size(18px, 23px);
       @include font-weight($semibold);
       margin: 0;
     }
 
     h4 {
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       @include font-weight($regular);
       margin: 0;
     }

--- a/public/themes/custom/suomidigi/src/scss/components/form/_form.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/form/_form.scss
@@ -62,8 +62,7 @@
   }
 
   .fieldset-legend {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     display: inline-block;
     font-weight: normal;
   }
@@ -76,22 +75,20 @@
       margin: 0;
 
       label {
-        @include font-size(16px);
-        @include line-height(16px, 19px);
+        @include font-size(16px, 19px);
         font-weight: normal;
       }
     }
   }
 
   .form-item {
+    @include font-size(16px, 24px);
     display: block;
-    line-height: 24px;
     margin: 0 0 6px;
     padding: 0;
 
     label:not(.visually-hidden) {
-      @include font-size(16px);
-      @include line-height(14px, 24px);
+      @include font-size(16px, 24px);
       color: #333333;
       display: inline-block;
       font-weight: normal;
@@ -102,8 +99,7 @@
     }
 
     .description {
-      @include font-size(13px);
-      @include line-height(13px, 20px);
+      @include font-size(13px, 20px);
     }
 
     select,

--- a/public/themes/custom/suomidigi/src/scss/components/form/_search.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/form/_search.scss
@@ -118,8 +118,7 @@
 }
 
 .search-form__button {
-  @include font-size(14px);
-  @include line-height(14px, 18px);
+  @include font-size(14px, 18px);
   background-color: $blue-light;
   border: 1px solid $blue-light;
   border-radius: 3px;

--- a/public/themes/custom/suomidigi/src/scss/components/form/_webform.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/form/_webform.scss
@@ -8,17 +8,15 @@
 .webform-submission-form {
   h2 {
     color: $blue-medium;
-    @include font-size(26px);
+    @include font-size(26px, 33px);
     @include font-weight($semibold);
-    @include line-height(26px, 33px);
     margin-bottom: $gutter / 2;
     margin-top: $gutter;
   }
 
   input,
   textarea {
-    @include font-size(14px);
-    @include line-height(14px, 20px);
+    @include font-size(14px, 20px);
 
     &::-ms-input-placeholder, /* Microsoft Edge */
     &:-ms-input-placeholder, /* Internet Explorer 10-11 */
@@ -175,8 +173,7 @@
       padding: $gutter;
 
       th {
-        @include font-size(14px);
-        @include line-height(14px, 22px);
+        @include font-size(14px, 22px);
         font-weight: 600;
         text-align: left;
       }
@@ -192,8 +189,7 @@
 
     .form-item {
       label:not(.visually-hidden) {
-        @include font-size(18px);
-        @include line-height(18px, 26px);
+        @include font-size(18px, 26px);
         margin-top: $gutter * 1.4;
       }
 

--- a/public/themes/custom/suomidigi/src/scss/components/misc/_button.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/misc/_button.scss
@@ -13,8 +13,7 @@
 
     a {
       @include button;
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       background-color: $white;
       border: 1px solid $blue;
       box-shadow: 0 3px 6px #00000029;

--- a/public/themes/custom/suomidigi/src/scss/components/misc/_link.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/misc/_link.scss
@@ -1,6 +1,5 @@
 .link {
-  @include font-size(18px);
-  @include line-height(18px, 23px);
+  @include font-size(18px, 23px);
   @include font-weight($semibold);
   color: $blue-light;
   font-weight: 600;
@@ -80,8 +79,7 @@
     }
 
     .link__text {
-      @include font-size(18px);
-      @include line-height(18px, 23px);
+      @include font-size(18px, 23px);
       @include font-weight($semibold);
       padding-right: $gutter / 4;
     }
@@ -89,8 +87,7 @@
 
   &--cta {
     display: flex;
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
     @include font-weight($semibold);
     margin-top: $gutter;
     transition: all 150ms linear;

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_local-tasks.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_local-tasks.scss
@@ -15,8 +15,7 @@
 
     a {
       @include button;
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
 
       background-color: $white;
       border: 1px solid $blue;

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-account.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-account.scss
@@ -46,8 +46,7 @@
     }
 
     .logged-out {
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       color: $blue-light;
       font-weight: 600;
       letter-spacing: 0;
@@ -100,8 +99,7 @@
         }
 
         .menu-item {
-          @include font-size(14px);
-          @include line-height(14px, 18px);
+          @include font-size(14px, 18px);
           font-weight: 600;
 
           a {
@@ -121,8 +119,7 @@
     }
 
     &__button {
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       background-color: $white;
       border: 0 none;
       color: $blue-light;

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-content-creation.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-content-creation.scss
@@ -20,8 +20,7 @@
   }
 
   &__button {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     background-color: transparent;
     border: 0 none;
     color: $blue-light;
@@ -106,8 +105,7 @@
     }
 
     .links li {
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       align-items: center;
       display: flex;
       font-weight: 600;

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-desktop.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-desktop.scss
@@ -18,7 +18,7 @@ nav.menu--desktop {
   }
 
   .menu-item {
-    @include line-height(18px, 23px);
+    @include font-size(18px, 23px);
     margin: 0 $gutter * 1.4;
     padding: 0;
     text-align: center;

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-language.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-language.scss
@@ -16,8 +16,7 @@
     }
 
     &__button {
-      @include font-size(14px);
-      @include line-height(14px, 14px);
+      @include font-size(14px, 14px);
       align-items: center;
       background-color: $white;
       border: 1px solid $blue;
@@ -93,8 +92,7 @@
         padding-top: 10px;
 
         .language-link {
-          @include font-size(16px);
-          @include line-height(16px, 26px);
+          @include font-size(16px, 26px);
           border-left: 6px solid transparent;
           color: $blue-dark;
           display: block;

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-mobile.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-mobile.scss
@@ -15,8 +15,7 @@
   justify-content: center;
 
   p {
-    @include font-size(14px);
-    @include line-height(14px, 16px);
+    @include font-size(14px, 16px);
     color: white;
     margin-bottom: 0;
     max-width: 200px;
@@ -61,8 +60,7 @@
 
       > span,
       > a {
-        @include font-size(14px);
-        @include line-height(14px, 17px);
+        @include font-size(14px, 17px);
         color: $black;
         display: block;
         padding: 0.75rem 1rem;
@@ -86,8 +84,7 @@
       &--lvl-0 {
         > span,
         > a {
-          @include font-size(18px);
-          @include line-height(18px, 18px);
+          @include font-size(18px, 18px);
           font-weight: bold;
           padding: 0.75rem 1rem;
         }

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-sidebar.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_menu-sidebar.scss
@@ -23,8 +23,7 @@ nav.menu--sidebar {
 
     > span,
     > a {
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       color: $blue;
       display: block;
       padding: 0.75rem 0;

--- a/public/themes/custom/suomidigi/src/scss/components/navigation/_shortcuts.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/navigation/_shortcuts.scss
@@ -5,8 +5,7 @@
     width: 100%;
 
     h2 {
-      @include font-size(14px);
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
       color: $white;
       font-weight: 600;
       letter-spacing: 0;
@@ -16,8 +15,7 @@
     }
 
     a {
-      @include font-size(22px);
-      @include line-height(22px, 28px);
+      @include font-size(22px, 28px);
       color: $white;
       display: block;
       font-weight: 600;

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--attachment.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--attachment.scss
@@ -4,8 +4,7 @@
   padding-top: $gutter;
 
   .paragraph__title {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     @include font-weight($semibold);
     color: $blue;
     margin-bottom: $gutter * 1.75;
@@ -30,8 +29,7 @@
 
     .attachment-teaser__title {
       .group__content & {
-        @include font-size(18px);
-        @include line-height(18px, 22px);
+        @include font-size(18px, 22px);
         @include font-weight($semibold);
       }
     }

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--banner.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--banner.scss
@@ -54,28 +54,25 @@
   }
 
   .paragraph__title {
-    @include font-size(18px);
-    @include line-height(18px, 20px);
+    @include font-size(18px, 20px);
     color: $white;
     font-weight: bold;
 
     @include breakpoint($for-mobile-portrait-up) {
-      @include font-size(20px);
-      @include line-height(20px, 25px);
+      @include font-size(20px, 25px);
       display: block;
       max-width: 490px;
     }
   }
 
   .paragraph__description {
-    @include font-size(14px);
-    @include line-height(14px, 14px);
+    @include font-size(14px, 14px);
 
     color: $white;
 
     font-weight: 600;
     @include breakpoint($for-mobile-portrait-up) {
-      @include line-height(14px, 18px);
+      @include font-size(14px, 18px);
     }
 
     &-icon {
@@ -138,8 +135,7 @@
     }
 
     .paragraph__title {
-      @include font-size(16px);
-      @include line-height(16px, 20px);
+      @include font-size(16px, 20px);
       color: $blue-medium;
       font-weight: 600;
       margin-bottom: $gutter;
@@ -155,11 +151,11 @@
 
     .paragraph__description {
       @include font-size(14px);
+      @include font-weight($bold);
       background-color: $blue-light;
       border: 2px solid $blue-light;
       color: $white;
       display: inline-block;
-      font-weight: bold;
       padding: $gutter / 2 $gutter;
       text-align: center;
       text-transform: uppercase;

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--box.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--box.scss
@@ -14,14 +14,12 @@
       max-width: 164px;
 
       .paragraph__title {
-        @include font-size(14px);
-        @include line-height(16px, 14px);
+        @include font-size(14px, 16px);
         margin-bottom: $gutter / 2;
       }
 
       .paragraph__content {
-        @include font-size(12px);
-        @include line-height(16px, 12px);
+        @include font-size(12px, 16px);
         display: inline-block;
       }
     }
@@ -104,8 +102,7 @@
   }
 
   .paragraph__title {
-    @include font-size(14px);
-    @include line-height(14px, 14px);
+    @include font-size(14px, 14px);
     font-weight: 600;
   }
 

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--contact-information.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--contact-information.scss
@@ -3,8 +3,7 @@
   padding-top: $gutter * 2;
 
   .paragraph__title {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     @include font-weight($semibold);
     color: $blue;
   }
@@ -49,12 +48,10 @@
   }
 
   .contact-information {
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
 
     &__name {
-      @include font-size(18px);
-      @include line-height(18px, 26px);
+      @include font-size(18px, 26px);
       @include font-weight($semibold);
       margin-bottom: 0;
     }

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--container-title.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--container-title.scss
@@ -5,8 +5,7 @@
     padding: calc(#{$gutter} * 0.5) $gutter;
 
     .paragraph__title {
-      @include font-size(20px);
-      @include line-height(20px, 26px);
+      @include font-size(20px, 26px);
       color: $blue;
       display: inline-block;
       font-weight: 600;
@@ -14,8 +13,7 @@
       margin: 0;
 
       @include breakpoint($for-tablet-landscape-up) {
-        @include font-size(22px);
-        @include line-height(22px, 28px);
+        @include font-size(22px, 28px);
       }
     }
 

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--entity-reference.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--entity-reference.scss
@@ -9,8 +9,7 @@
 
   &.paragraph--3col {
     .paragraph__title {
-      @include font-size(28px);
-      @include line-height(28px, 36px);
+      @include font-size(28px, 36px);
       @include font-weight($semibold);
       color: $blue;
     }
@@ -74,8 +73,7 @@
     width: 100%;
 
     > a {
-      @include font-size(16px);
-      @include line-height(16px, 20px);
+      @include font-size(16px, 20px);
       @include font-weight($semibold);
       border: 1px solid $blue;
       border-radius: 3px;

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--group-views.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--group-views.scss
@@ -2,8 +2,7 @@
   padding: $gutter * 2 0;
 
   .paragraph__title {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     @include font-weight($semibold);
     color: $blue;
     margin-bottom: $gutter * 2;
@@ -11,8 +10,7 @@
 
   .paragraph__description,
   .paragraph__description p {
-    @include font-size(20px);
-    @include line-height(20px, 26px);
+    @include font-size(20px, 26px);
     @include font-weight($regular);
     color: $black;
   }

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--hero.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--hero.scss
@@ -69,48 +69,41 @@
   }
 
   .paragraph__title {
-    @include font-size(22px);
-    @include line-height(22px, 30px);
+    @include font-size(22px, 30px);
     @include font-weight($bold);
     color: $white;
     margin-bottom: $gutter;
 
     @include breakpoint($for-tablet-portrait-up) {
-      @include font-size(29px);
-      @include line-height(29px, 40px);
+      @include font-size(29px, 40px);
     }
 
     @include breakpoint($for-tablet-landscape-up) {
-      @include font-size(40px);
-      @include line-height(40px, 50px);
+      @include font-size(40px, 50px);
       margin-bottom: $gutter * 2;
     }
   }
 
   .paragraph__description {
-    @include font-size(16px);
-    @include line-height(16px, 22px);
+    @include font-size(16px, 22px);
     @include font-weight($regular);
     color: $white;
     margin-bottom: $gutter;
 
     @include breakpoint($for-tablet-portrait-up) {
-      @include font-size(18px);
-      @include line-height(18px, 26px);
+      @include font-size(18px, 26px);
       margin: 0 auto $gutter auto;
       max-width: 570px;
     }
 
     @include breakpoint($for-tablet-landscape-up) {
-      @include font-size(22px);
-      @include line-height(22px, 30px);
+      @include font-size(22px, 30px);
       margin: 0 auto $gutter * 2 auto;
     }
   }
 
   .paragraph__hero-link {
-    @include font-size(16px);
-    @include line-height(16px, 20px);
+    @include font-size(16px, 20px);
     @include font-weight($semibold);
     border: 1px solid $white;
     border-radius: 3px;

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--liftup-50-50.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--liftup-50-50.scss
@@ -1,0 +1,97 @@
+.paragraph--liftup-50-50 {
+  align-items: center;
+  background-color: $white;
+  display: flex;
+  flex-direction: column;
+
+  &.paragraph {
+    margin: 0;
+  }
+
+  @include breakpoint($for-tablet-portrait-up) {
+    flex-direction: row;
+  }
+
+  &.paragraph--reverse {
+    .paragraph__media {
+      @include breakpoint($for-tablet-portrait-up) {
+        order: 2;
+      }
+    }
+  }
+
+  .paragraph__media {
+    align-self: stretch;
+    line-height: 0;
+    min-height: 100%;
+    order: 1;
+
+    @include breakpoint($for-tablet-portrait-up) {
+      width: 50%;
+
+      img {
+        object-fit: cover;
+        width: 100%;
+      }
+
+      * {
+        height: 100%;
+      }
+
+      .media-image__creator {
+        height: auto;
+      }
+    }
+  }
+
+  .paragraph__content-wrapper {
+    order: 2;
+    padding: $gutter * 2;
+
+    @include breakpoint($for-tablet-portrait-up) {
+      width: 50%;
+    }
+  }
+
+  .paragraph__title-wrapper {
+    .link__icon-left {
+      .icon {
+        height: 35px;
+        margin-left: -11px;
+        width: 35px;
+      }
+    }
+
+    .link__icon-right {
+      .icon {
+        height: 22px;
+        left: 7px;
+        top: 7px;
+        width: 22px;
+      }
+    }
+  }
+
+  .paragraph__title {
+    @include font-size(28px, 34px);
+    @include font-weight($semibold);
+  }
+
+  .paragraph.paragraph--list-of-links {
+    border: 0 none;
+
+    .paragraph__title {
+      @include font-size(22px, 28px);
+      @include font-weight($semibold);
+      text-transform: none;
+    }
+  }
+
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--list-of-links.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--list-of-links.scss
@@ -3,8 +3,7 @@
   padding-top: $gutter * 2;
 
   .paragraph__title {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     @include font-weight($semibold);
     color: $blue;
     margin-bottom: $gutter * 1.75;

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--media.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--media.scss
@@ -4,14 +4,12 @@
   }
 
   .paragraph__text {
-    @include font-size(14px);
-    @include line-height(14px, 22px);
-    margin-top: $gutter * .5;
+    @include font-size(14px, 22px);
     color: $gray-darker;
+    margin-top: $gutter * .5;
 
     @include breakpoint($for-tablet-portrait-up) {
-      @include font-size(15px);
-      @include line-height(15px, 22px);
+      @include font-size(15px, 22px);
     }
   }
 }

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--text-box.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph--text-box.scss
@@ -10,8 +10,7 @@
   .paragraph__content {
     li,
     p {
-      @include font-size(14px);
-      @include line-height(14px, 22px);
+      @include font-size(14px, 22px);
     }
 
     li {

--- a/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/paragraph/_paragraph.scss
@@ -14,16 +14,14 @@
   }
 
   > .paragraph__title {
-    @include font-size(28px);
-    @include line-height(28px, 36px);
+    @include font-size(28px, 36px);
     @include font-weight($semibold);
     color: $blue;
     margin-bottom: $gutter * 2;
   }
 
   > .paragraph__description {
-    @include font-size(18px);
-    @include line-height(18px, 26px);
+    @include font-size(18px, 26px);
     @include font-weight($regular);
     margin-bottom: $gutter * 2;
 
@@ -38,8 +36,7 @@
     width: 100%;
 
     > a {
-      @include font-size(16px);
-      @include line-height(16px, 20px);
+      @include font-size(16px, 20px);
       @include font-weight($semibold);
       border: 1px solid $blue;
       border-radius: 3px;

--- a/public/themes/custom/suomidigi/src/scss/components/profile/_profile-card.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/profile/_profile-card.scss
@@ -69,8 +69,7 @@
   }
 
   &__name {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     color: $blue;
     font-weight: 600;
     letter-spacing: 0;
@@ -82,8 +81,7 @@
   }
 
   &__profession {
-    @include font-size(14px);
-    @include line-height(14px, 18px);
+    @include font-size(14px, 18px);
     font-weight: 600;
     letter-spacing: 0;
 
@@ -93,8 +91,7 @@
   }
 
   &__description {
-    @include font-size(16px);
-    @include line-height(16px, 24px);
+    @include font-size(16px, 24px);
     letter-spacing: 0;
     margin-bottom: $gutter;
   }
@@ -165,8 +162,7 @@
     }
 
     .profile-card__name {
-      @include font-size(18px);
-      @include line-height(18px, 26px);
+      @include font-size(18px, 26px);
       @include font-weight($semibold);
       color: $blue-light;
       margin: 0;

--- a/public/themes/custom/suomidigi/src/scss/components/profile/_profile.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/profile/_profile.scss
@@ -11,8 +11,7 @@
   }
 
   h2 {
-    @include font-size(22px);
-    @include line-height(22px, 28px);
+    @include font-size(22px, 28px);
     @include border('bottom');
     color: $blue;
     font-weight: 600;

--- a/public/themes/custom/suomidigi/src/scss/components/views/_pager.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/views/_pager.scss
@@ -14,8 +14,7 @@
     }
 
     .button {
-      @include font-size(16px);
-      @include line-height(16px, 20px);
+      @include font-size(16px, 20px);
       @include font-weight($semibold);
       background-color: $blue;
       border: 2px solid $blue;

--- a/public/themes/custom/suomidigi/src/scss/components/views/_views--articles.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/views/_views--articles.scss
@@ -7,16 +7,14 @@
 
     .form-item-thid {
       label {
-        @include font-size(22px);
-        @include line-height(22px, 28px);
+        @include font-size(2222px, 28px);
         @include font-weight($semibold);
         color: $blue;
         margin-bottom: $gutter;
       }
 
       select {
-        @include font-size(18px);
-        @include line-height(18px, 23px);
+        @include font-size(1818px, 23px);
         @include font-weight($regular);
         -moz-appearance: none;
         -webkit-appearance: none;
@@ -47,8 +45,7 @@
     width: 100%;
 
     .views-field-name {
-      @include font-size(22px);
-      @include line-height(22px, 28px);
+      @include font-size(22px, 28px);
       @include font-weight($semibold);
       margin-bottom: $gutter;
 
@@ -59,8 +56,7 @@
     }
 
     .views-field-field-theme-description {
-      @include font-size(18px);
-      @include line-height(18px, 27px);
+      @include font-size(18px, 27px);
       @include font-weight($regular);
       max-width: 670px;
     }

--- a/public/themes/custom/suomidigi/src/scss/components/views/_views-title.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/views/_views-title.scss
@@ -1,6 +1,5 @@
 .views__title {
-  @include font-size(22px);
-  @include line-height(22px, 28px);
+  @include font-size(22px, 28px);
   @include font-weight($semibold);
   color: $blue;
   margin: $gutter * 2 0

--- a/public/themes/custom/suomidigi/src/scss/layout/_page-announcement.scss
+++ b/public/themes/custom/suomidigi/src/scss/layout/_page-announcement.scss
@@ -32,13 +32,11 @@
   }
 
   p {
-    @include font-size(13px);
-    @include line-height(13px, 18px);
+    @include font-size(13px, 18px);
     margin: 0;
 
     @include breakpoint($for-tablet-portrait-up) {
-      @include font-size(14px);
-      @include line-height(14px, 20px);
+      @include font-size(14px, 20px);
     }
   }
 

--- a/public/themes/custom/suomidigi/src/scss/library/mixins/_mixins.scss
+++ b/public/themes/custom/suomidigi/src/scss/library/mixins/_mixins.scss
@@ -1,19 +1,8 @@
-@mixin font-size($font-size, $desired-mobile-size: '') {
-  @media screen and (max-width: $for-tablet-portrait-up) {
-    @if $desired-mobile-size != '' {
-      font-size: ($desired-mobile-size / $base-font-size) * 1rem;
-    }
-  }
+@mixin font-size($font-size, $line-height: '') {
   font-size: ($font-size / $base-font-size) * 1rem;
-}
-
-@mixin line-height($font-size, $line-height, $mobile-font-size: '', $mobile-line-height: '') {
-  @media screen and (max-width: $for-tablet-portrait-up) {
-    @if $mobile-font-size != '' and $mobile-line-height != '' {
-      line-height: ($mobile-line-height / $mobile-font-size) * $mobile-font-size;
-    }
+  @if $line-height != '' {
+    line-height: ($line-height / $font-size) * $font-size;
   }
-  line-height: ($line-height / $font-size) * $font-size;
 }
 
 @mixin font-weight($font-weight) {
@@ -54,8 +43,7 @@
     }
   }
   @else if $type == 'submit' {
-    @include font-size(14px);
-    @include line-height(14px, 14px);
+    @include font-size(14px, 14px);
     @include font-weight($semibold);
     background-color: $blue-light;
     border: 2px solid $blue-light;

--- a/public/themes/custom/suomidigi/templates/paragraph/paragraph--liftup-50-50.html.twig
+++ b/public/themes/custom/suomidigi/templates/paragraph/paragraph--liftup-50-50.html.twig
@@ -1,0 +1,58 @@
+{% extends "paragraph.html.twig" %}
+
+{% block paragraph %}
+  {% set reverse = content.field_p_reverse['0']['#markup'] %}
+
+  {% if reverse is same as(1) %}
+    {% set classes = classes|merge(['paragraph--reverse']) %}
+  {% endif %}
+
+  <div{{attributes.addClass(classes)}}>
+    {% block content %}
+      <div class="paragraph__content-wrapper">
+        <div class="paragraph__title-wrapper">
+          {% if content.field_p_link.0['#url'] %}
+            {% set link = content.field_p_link.0['#url'] %}
+            {% set text = content.field_p_title.0 %}
+            {% set external = item.is_external %}
+
+            <a class="link--secondary" href="{{ link }}" {% if external == true %} target="_blank" {% endif %}>
+              {% if icons_path %}
+                <div class="link__icon-left">
+                  <svg class="icon">
+                    <title>{{ text }}</title>
+                    <use xlink:href="{{ icons_path|trim }}#chevron-right"/>
+                  </svg>
+                </div>
+              {% endif %}
+              <h2 class="paragraph__title link__text">{{ text }}</h2>
+              {% if icons_path and external != true %}
+                <span class="link__icon-right">
+                  <svg class="icon">
+                    <title>{{ text }}</title>
+                    <use xlink:href="{{ icons_path|trim }}#link-external"/>
+                  </svg>
+                </span>
+              {% endif %}
+            </a>
+          {% else %}
+            <h2 class="paragraph__title">{{ content.field_p_title.0 }}</h2>
+          {% endif %}
+        </div>
+        <div class="paragraph__content">
+          {{ content|without(
+            'field_p_title',
+            'field_p_reverse',
+            'field_p_link',
+            'field_p_media'
+          ) }}
+        </div>
+      </div>
+      <div class="paragraph__media">
+        {% if content.field_p_media|render %}
+          {{ content.field_p_media|render }}
+        {% endif %}
+      </div>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
To test: 
- `make fresh` (and clear caches after logging in)
- Log in and go to create a new landing page (https://suomidigi.docker.sh/node/add/landing_page)
- Give the page a title and add new paragraph called Liftup 50/50
   - Give the liftup a title, image and text.
   - Save the node and check that the layout is similar to the one on link below, except that the width of the liftup 50/50 is content wide - not screen width wide.
       - https://xd.adobe.com/view/c1b40caa-b2e0-43a5-78d8-9690a43f540c-b785/screen/2585ee1f-a81b-49a3-976f-98c0bdbcbf87/Suomidigi-ohjeet-tuki-koonti/
- Edit the node and duplicate Liftup 50/50 from the three dots
   - Alter the values and select the "Reverse" option
   - Save the node and check that the layout works on "reverse mode" as well.
- Also check that the layout works on mobile width