### PR TITLE
SUOPA-907 Legislation card attachment

### DIFF
--- a/conf/cmi/core.entity_form_display.node.legislation_card.default.yml
+++ b/conf/cmi/core.entity_form_display.node.legislation_card.default.yml
@@ -3,15 +3,19 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.media_attachment_browser
     - field.field.node.legislation_card.field_attachments
     - field.field.node.legislation_card.field_displayed_update_time
     - field.field.node.legislation_card.field_ingress
+    - field.field.node.legislation_card.field_lc_attachments
     - field.field.node.legislation_card.field_legislation_content
     - field.field.node.legislation_card.field_legislation_materials
     - field.field.node.legislation_card.field_legislation_section
     - node.type.legislation_card
   module:
+    - content_moderation
     - datetime
+    - entity_browser
     - hide_revision_field
     - paragraphs
     - path
@@ -33,7 +37,7 @@ content:
     third_party_settings: {  }
   field_attachments:
     type: paragraphs
-    weight: 18
+    weight: 19
     region: content
     settings:
       title: Paragraph
@@ -51,7 +55,7 @@ content:
         add_above: '0'
     third_party_settings: {  }
   field_displayed_update_time:
-    weight: 19
+    weight: 20
     settings: {  }
     third_party_settings:
       timepicker:
@@ -69,6 +73,20 @@ content:
     third_party_settings: {  }
     type: string_textarea
     region: content
+  field_lc_attachments:
+    type: entity_browser_entity_reference
+    weight: 17
+    settings:
+      entity_browser: media_attachment_browser
+      field_widget_display: label
+      field_widget_edit: true
+      field_widget_remove: true
+      open: true
+      selection_mode: selection_append
+      field_widget_replace: false
+      field_widget_display_settings: {  }
+    third_party_settings: {  }
+    region: content
   field_legislation_content:
     weight: 16
     settings:
@@ -79,7 +97,7 @@ content:
     region: content
   field_legislation_materials:
     type: paragraphs
-    weight: 17
+    weight: 18
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -102,6 +120,7 @@ content:
       match_operator: CONTAINS
       autocomplete: false
       width: 100%
+      match_limit: 10
     third_party_settings: {  }
     type: select2_entity_reference
     region: content
@@ -114,7 +133,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 21
     settings: {  }
     region: content
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.legislation_card.default.yml
+++ b/conf/cmi/core.entity_view_display.node.legislation_card.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.legislation_card.field_attachments
     - field.field.node.legislation_card.field_displayed_update_time
     - field.field.node.legislation_card.field_ingress
+    - field.field.node.legislation_card.field_lc_attachments
     - field.field.node.legislation_card.field_legislation_content
     - field.field.node.legislation_card.field_legislation_materials
     - field.field.node.legislation_card.field_legislation_section
@@ -44,6 +45,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_lc_attachments:
+    type: entity_reference_entity_view
+    weight: 6
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
     region: content
   field_legislation_content:
     weight: 2

--- a/conf/cmi/core.entity_view_display.node.legislation_card.search_index.yml
+++ b/conf/cmi/core.entity_view_display.node.legislation_card.search_index.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.legislation_card.field_attachments
     - field.field.node.legislation_card.field_displayed_update_time
     - field.field.node.legislation_card.field_ingress
+    - field.field.node.legislation_card.field_lc_attachments
     - field.field.node.legislation_card.field_legislation_content
     - field.field.node.legislation_card.field_legislation_materials
     - field.field.node.legislation_card.field_legislation_section
@@ -41,6 +42,7 @@ content:
 hidden:
   field_attachments: true
   field_displayed_update_time: true
+  field_lc_attachments: true
   field_legislation_content: true
   field_legislation_materials: true
   field_legislation_section: true

--- a/conf/cmi/core.entity_view_display.node.legislation_card.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.legislation_card.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.legislation_card.field_attachments
     - field.field.node.legislation_card.field_displayed_update_time
     - field.field.node.legislation_card.field_ingress
+    - field.field.node.legislation_card.field_lc_attachments
     - field.field.node.legislation_card.field_legislation_content
     - field.field.node.legislation_card.field_legislation_materials
     - field.field.node.legislation_card.field_legislation_section
@@ -59,6 +60,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_displayed_update_time: true
+  field_lc_attachments: true
   field_legislation_section: true
   langcode: true
   published_at: true

--- a/conf/cmi/field.field.node.legislation_card.field_lc_attachments.yml
+++ b/conf/cmi/field.field.node.legislation_card.field_lc_attachments.yml
@@ -1,0 +1,30 @@
+uuid: 40111b39-48f0-4629-99dc-1e59ba24c835
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_lc_attachments
+    - media.type.attachment
+    - media.type.attachment_external
+    - node.type.legislation_card
+id: node.legislation_card.field_lc_attachments
+field_name: field_lc_attachments
+entity_type: node
+bundle: legislation_card
+label: Attachments
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      attachment: attachment
+      attachment_external: attachment_external
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: attachment
+field_type: entity_reference

--- a/conf/cmi/field.storage.node.field_lc_attachments.yml
+++ b/conf/cmi/field.storage.node.field_lc_attachments.yml
@@ -1,0 +1,20 @@
+uuid: f2f1b586-bc85-450e-ba86-7f85e6c3df32
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_lc_attachments
+field_name: field_lc_attachments
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.node.legislation_card.field_lc_attachments.yml
+++ b/conf/cmi/language/fi/field.field.node.legislation_card.field_lc_attachments.yml
@@ -1,0 +1,2 @@
+label: Liitetiedostot
+description: 'Voit valita useita liitetiedostoja.'

--- a/public/themes/custom/suomidigi/src/scss/components/content/_attachment.scss
+++ b/public/themes/custom/suomidigi/src/scss/components/content/_attachment.scss
@@ -4,6 +4,7 @@
   border-radius: $gutter / 3;
   box-shadow: 2px 2px 10px #00000033;
   height: 100%;
+  margin-bottom: $gutter;
   padding: $gutter;
   width: 100%;
 
@@ -39,7 +40,7 @@
   &__file-type {
     @include font-size(18px, 26px);
     @include font-weight($regular);
-    color: $gray-dark;
+    color: $gray;
     margin-bottom: 0;
     text-transform: uppercase;
   }
@@ -49,12 +50,11 @@
     text-decoration: none;
 
     &:hover {
-      .attachment-teaser__title {
+      .attachment-teaser__title,
+      .attachment-teaser__icon .icon,
+      .attachment-teaser__file-type {
         color: $black;
         text-decoration: underline;
-      }
-      .attachment-teaser__icon .icon {
-        color: $black;
       }
     }
   }

--- a/public/themes/custom/suomidigi/templates/content/node--legislation-card--full.html.twig
+++ b/public/themes/custom/suomidigi/templates/content/node--legislation-card--full.html.twig
@@ -43,6 +43,11 @@
         {{ content.field_legislation_content }}
       </div>
     {% endif %}
+    {% if content.field_lc_attachments|render %}
+      <div class="legislation-card__support-attachments">
+        {{ content.field_lc_attachments }}
+      </div>
+    {% endif %}
     <div class="legislation-card__data">
       <span class="legislation-card__modified-text">{{ 'Updated'|trans }}:</span>
       <span class="legislation-card__modified-date">{{ node.getChangedTime()|date('j.n.Y') }}</span>


### PR DESCRIPTION
To test: 
- `make fresh`
- Log in and go to edit a legislation card. F.e. https://suomidigi.docker.sh/node/140/edit
   - Scroll down until you see Attachments (Liitetiedostot)
![image](https://user-images.githubusercontent.com/1712902/76750018-3030bb00-6786-11ea-9d35-6f8499414c39.png)
   - Add few attachments and save the page.
- Check that the attachment is similar to proto: https://xd.adobe.com/view/d3c60a1d-1d76-4a8b-4797-030e9c2e717f-a5f7/screen/28cce598-ed5e-4849-8cbb-76b1db23d871/Suomidigi-2020-lainsaadanto-proto1-2-XL-2/