### PR TITLE
SUOPA-770 User delete after period

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "drupal/pathauto": "^1.0",
         "drupal/preview_link": "^1.3",
         "drupal/publication_date": "^2.0",
+        "drupal/purge_users": "^1.9",
         "drupal/rabbit_hole": "^1.0@beta",
         "drupal/rate": "^1.0",
         "drupal/recaptcha": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2ce9323c72caa5fc2bdd4e98ba698f4",
+    "content-hash": "92609826d10e88fbec048a04d7a43335",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1387,18 +1387,12 @@
             "version": "1.1.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/dimsemenov/Magnific-Popup/archive/1.1.0.zip",
-                "reference": "6b7a8088783cbce01034414c1fd2d8e1889093ae",
-                "shasum": ""
+                "url": "https://github.com/dimsemenov/Magnific-Popup/archive/1.1.0.zip"
             },
             "type": "drupal-library",
             "extra": {
                 "installer-name": "magnific-popup"
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "description": "Light and responsive lightbox script with focus on performance.",
-            "homepage": "http://dimsemenov.com/plugins/magnific-popup/",
-            "time": "2016-02-20T09:06:30+00:00"
+            }
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -3023,7 +3017,8 @@
                     "https://www.drupal.org/project/drupal/issues/3045648": "https://www.drupal.org/files/issues/2019-04-23/3045648-17-do-not-test.patch",
                     "https://www.drupal.org/project/drupal/issues/2946750": "https://www.drupal.org/files/issues/2019-03-22/2946750-19.patch",
                     "https://www.drupal.org/project/drupal/issues/2927455": "https://www.drupal.org/files/issues/2020-02-13/2927455-8.patch",
-                    "https://www.drupal.org/project/drupal/issues/3101344": "https://www.drupal.org/files/issues/2020-02-12/translations_not_save_invalid_path-3101344-20.patch"
+                    "https://www.drupal.org/project/drupal/issues/3101344": "https://www.drupal.org/files/issues/2020-02-12/translations_not_save_invalid_path-3101344-20.patch",
+                    "Remove node_user_predelete() hook to prevent deletion of nodes when deleting a user account.": "patches/remove_node_user_predelete_hook.patch"
                 }
             },
             "autoload": {
@@ -5760,6 +5755,53 @@
             }
         },
         {
+            "name": "drupal/purge_users",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/purge_users.git",
+                "reference": "8.x-1.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/purge_users-8.x-1.9.zip",
+                "reference": "8.x-1.9",
+                "shasum": "74b99d4bd3fcf4c790b4d3448d6f1b816141c733"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.9",
+                    "datestamp": "1543506480",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Drupalbee",
+                    "homepage": "https://www.drupal.org/user/2498674"
+                }
+            ],
+            "description": "Purge inactive users after a set interval.",
+            "homepage": "https://www.drupal.org/project/purge_users",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge_users"
+            }
+        },
+        {
             "name": "drupal/rabbit_hole",
             "version": "1.0.0-beta6",
             "source": {
@@ -7541,8 +7583,7 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": []
+                }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -86,6 +86,7 @@ module:
   path: 0
   path_alias: 0
   preview_link: 0
+  purge_users: 0
   quickedit: 0
   rabbit_hole: 0
   rate: 0

--- a/conf/cmi/language/fi/views.view.moderated_content.yml
+++ b/conf/cmi/language/fi/views.view.moderated_content.yml
@@ -6,6 +6,16 @@ display:
     display_title: 'Moderoitava sisältö'
   default:
     display_options:
+      filters:
+        moderation_state_1:
+          expose:
+            label: Julkaisutila
+        title:
+          expose:
+            label: Otsikko
+        moderation_state:
+          expose:
+            label: Julkaisutila
       exposed_form:
         options:
           submit_button: Suodata
@@ -42,19 +52,10 @@ display:
           separator: ', '
         operations:
           label: Toimenpiteet
-      filters:
-        title:
-          expose:
-            label: Otsikko
-        moderation_state:
-          expose:
-            label: Julkaisutila
-        moderation_state_1:
-          expose:
-            label: Julkaisutila
       title: 'Moderoitava sisältö'
       empty:
         area_text_custom:
           content: 'Moderoitavaa sisältöä ei löytynyt. Tällä sivulla listataan vain "Luonnos" tai "Odottaa julkaisua" tilassa olevat sisällöt.'
+    display_title: Isäntä
 label: 'Moderoitava sisältö'
 description: 'Etsi ja moderoi sisältöä'

--- a/conf/cmi/language/sv/system.menu.admin.yml
+++ b/conf/cmi/language/sv/system.menu.admin.yml
@@ -1,2 +1,1 @@
-label: Administration
 description: 'Länkar för administrativa uppgifter'

--- a/conf/cmi/purge_users.settings.yml
+++ b/conf/cmi/purge_users.settings.yml
@@ -20,7 +20,7 @@ purge_users_roles:
   group_administrator: 0
   groups_administrator: 0
   user_administrator: 0
-purge_on_cron: 0
+purge_on_cron: 1
 inactive_user_notify_text: "Dear User, \r\n\r\nYour account has been deleted due the website’s policy to automatically remove users who match certain criteria. If you have concerns regarding the deletion, please talk to the administrator of the website. \r\n\r\nThank you"
 send_email_notification: 0
 purge_user_cancel_method: user_cancel_delete

--- a/conf/cmi/purge_users.settings.yml
+++ b/conf/cmi/purge_users.settings.yml
@@ -1,0 +1,26 @@
+user_never_lastlogin_value: '3'
+user_never_lastlogin_period: year
+user_lastlogin_value: '3'
+user_lastlogin_period: year
+user_inactive_value: ''
+user_inactive_period: days
+user_blocked_value: ''
+user_blocked_period: days
+enabled_never_loggedin_users: 1
+enabled_loggedin_users: 1
+enabled_inactive_users: 0
+enabled_blocked_users: 0
+purge_users_roles:
+  authenticated: authenticated
+  content_producer: content_producer
+  group_member: group_member
+  editor_in_chief: 0
+  administrator: 0
+  webform_administrator: 0
+  group_administrator: 0
+  groups_administrator: 0
+  user_administrator: 0
+purge_on_cron: 0
+inactive_user_notify_text: "Dear User, \r\n\r\nYour account has been deleted due the website’s policy to automatically remove users who match certain criteria. If you have concerns regarding the deletion, please talk to the administrator of the website. \r\n\r\nThank you"
+send_email_notification: 0
+purge_user_cancel_method: user_cancel_delete


### PR DESCRIPTION
Check https://github.com/vrk-kpa/suomidigi/pull/213 first, as this branch is dependant of it
To test: 
- `make fresh`
- Create a user and set it's last access date to more than three years in the past. There's a drush command below to ease up the user creation
   - ```drush user:create suomidigi-testi --mail="suomidigi-testi@mailinator.com" --password="suomidigi-testi" && drush sqlq "UPDATE users_field_data SET access = 1426852000, created = 1426852000 WHERE mail = 'suomidigi-testi@mailinator.com'"```
- Log in and go to https://suomidigi.docker.sh/en/admin/people?user=&status=All&role=All&permission=All&order=access&sort=asc 
  - Check that the user has been created and that it's last access date is more than three years in the past. If the user is not on the list, flush all caches.
- Go to https://suomidigi.docker.sh/en/admin/config/system/cron
   - Click on run cron and make sure the user gets deleted. 
   - You can verify the user deletion from https://suomidigi.docker.sh/en/admin/reports/dblog or from people view.
