### PR TITLE
SUOPA-931 Test-users

### DIFF
--- a/conf/cmi/group.role.group-member.yml
+++ b/conf/cmi/group.role.group-member.yml
@@ -13,9 +13,15 @@ group_type: group
 permissions_ui: true
 permissions:
   - 'access group_node overview'
+  - 'create group_node:blog_post entity'
+  - 'create group_node:event entity'
   - 'create group_node:landing_page content'
   - 'leave group'
+  - 'update own group_node:blog_post entity'
+  - 'update own group_node:event entity'
   - 'view group'
   - 'view group_membership content'
+  - 'view group_node:blog_post entity'
+  - 'view group_node:event entity'
   - 'view unpublished group_node:article entity'
   - 'view unpublished group_node:core_content entity'

--- a/conf/cmi/key.key.test_users.yml
+++ b/conf/cmi/key.key.test_users.yml
@@ -1,0 +1,15 @@
+uuid: bf01cec6-9bba-43ff-a730-b3a59462919e
+langcode: fi
+status: true
+dependencies: {  }
+id: test_users
+label: 'Test users'
+description: 'This key has test users data stored'
+key_type: authentication
+key_type_settings: {  }
+key_provider: file
+key_provider_settings:
+  file_location: 'private://keys/test_users.key'
+  strip_line_breaks: true
+key_input: none
+key_input_settings: {  }

--- a/public/modules/custom/suopa_user/drush.services.yml
+++ b/public/modules/custom/suopa_user/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  suopa_user.commands:
+    class: \Drupal\suopa_user\Commands\GenerateTestUsers
+    tags:
+      - { name: drush.command }

--- a/public/modules/custom/suopa_user/src/Commands/GenerateTestUsers.php
+++ b/public/modules/custom/suopa_user/src/Commands/GenerateTestUsers.php
@@ -38,6 +38,8 @@ class GenerateTestUsers extends DrushCommands {
             $user->enforceIsNew();
             $user->activate();
             $user->setUsername($user_name);
+            $user->set('field_first_name', $user_data['first_name']);
+            $user->set('field_last_name', $user_data['last_name']);
 
             if (!empty($user_data['roles'])) {
               foreach ($user_data['roles'] as $role => $roles) {

--- a/public/modules/custom/suopa_user/src/Commands/GenerateTestUsers.php
+++ b/public/modules/custom/suopa_user/src/Commands/GenerateTestUsers.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\suopa_user\Commands;
+
+use Drupal\user\Entity\User;
+use Drupal\group\Entity\Group;
+use Drush\Commands\DrushCommands;
+use Drupal\key\Entity\Key;
+
+/**
+ * File for creating test users via drush.
+ */
+class GenerateTestUsers extends DrushCommands {
+
+  /**
+   * Constructs a new generateTestUsers object.
+   */
+  public function __construct() {
+
+  }
+
+  /**
+   * Generate test users.
+   *
+   * @command suopa_user:generateTestUsers
+   */
+  public function generateTestUsers() {
+    $data = \Drupal::service('key.repository')->getKey('test_users');
+
+    if (!empty($data) && $data instanceof Key) {
+      $users = unserialize($data->getKeyValue());
+
+      if (is_array($users)) {
+        foreach ($users as $user_name => $user_data) {
+          if (user_load_by_name($user_name) === FALSE) {
+            $user = User::create();
+            $user->setPassword($user_data['password']);
+            $user->enforceIsNew();
+            $user->activate();
+            $user->setUsername($user_name);
+
+            if (!empty($user_data['roles'])) {
+              foreach ($user_data['roles'] as $role => $roles) {
+                if (isset($role) && $role == 'role') {
+                  $user->addRole($roles);
+                }
+              }
+            }
+
+            $user->save();
+            $this->logger()->success(dt('User @user has been created.', ['@user' => $user_name]));
+
+            if (!empty($user_data['group'])) {
+              $account = User::load($user->id());
+              $group = Group::load($user_data['group']);
+
+              if (isset($user_data['roles']['group'])) {
+                $group->addMember($account, ['group_roles' => $user_data['roles']['group']]);
+              }
+              else {
+                $group->addMember($account);
+              }
+              $group->save();
+            }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/scripts/post-install-beta.sh
+++ b/scripts/post-install-beta.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd /app/public
+
+drush suopa_user:generateTestUsers


### PR DESCRIPTION
To test:
- `make fresh`
- Make sure you have test_users.key private file in a correct folder. This was sent to you via slack.
- run drush command `drush suopa_user:generateTestUsers`
- Log in and go to https://suomidigi.docker.sh/admin/people
- Check that there's users and that their data corresponds to https://wiki.dvv.fi/pages/viewpage.action?pageId=70751731
- Try to log in with one of the users. The users don't have email addresses, so fill in the user name to the email field. Like so: 
![image](https://user-images.githubusercontent.com/1712902/77756611-30f40780-7038-11ea-97f2-09863d7e2066.png)
