### PR TITLE
Fix block_account_menu_menu caching

### DIFF
--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -572,7 +572,7 @@ function suomidigi_preprocess_menu(&$variables) {
       ? $first_name . ' ' . $last_name
       : $user->getDisplayName();
 
-    // Set caching / user
+    // Set caching / user.
     $variables['#cache']['contexts'][] = 'user';
   }
 }

--- a/public/themes/custom/suomidigi/suomidigi.theme
+++ b/public/themes/custom/suomidigi/suomidigi.theme
@@ -571,6 +571,9 @@ function suomidigi_preprocess_menu(&$variables) {
     $variables['user_name'] = (isset($first_name) && isset($last_name))
       ? $first_name . ' ' . $last_name
       : $user->getDisplayName();
+
+    // Set caching / user
+    $variables['#cache']['contexts'][] = 'user';
   }
 }
 


### PR DESCRIPTION
In some cases wrong username can be left into top right corner block_account_menu_menu.

This PR will fix this with enabling user context to caching.

Testing guide:
- Build local environment
- Comment out lines 19-21 in dev.settings.php to enable caching in local 
`#$settings['cache']['bins']['render'] = 'cache.backend.null';
#$settings['cache']['bins']['page'] = 'cache.backend.null';
#$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';`
- Clear caches

- As anonymous user create user with name you can remember. Log in and see your profile (Email sending does not work in local so you need to uli). Check that right username appears in top right corner. (This would work even without fix)
- Logout

- As anonymous user create second user with name you can remember. Log in and see your profile (Email sending does not work in local so you need to uli). Check that right username appears in top right corner. (This would fail without this fix)