### PR TITLE
SUOPA-X Entity browser

### DIFF
--- a/public/modules/custom/suopa_dream_broker/assets/js/handleDreamBrokerTitle.js
+++ b/public/modules/custom/suopa_dream_broker/assets/js/handleDreamBrokerTitle.js
@@ -3,7 +3,7 @@
   let oembed = $('.field--name-field-media-oembed-video input');
   title.hide();
 
-  if (oembed !== undefined) {
+  if (typeof oembed.val() !== "undefined") {
     if (oembed.val().match(/(dreambroker)/)) {
       title.show();
     }


### PR DESCRIPTION
It seemed that one single flaw in JS file broke down the entire entity browser.

Testing guide: 
- Login to https://suomidigi.docker.sh and head to https://suomidigi.docker.sh/node/add/landing-page
- Inspect the page and select console tab from inspector
- Add new media paragraph and click on "Valitse media"
- When the media browser opens in to a modal, check that there's no javascript error in the console

![image](https://user-images.githubusercontent.com/1712902/94797803-50a22900-03e9-11eb-9c9c-87a1830924ec.png)
